### PR TITLE
fix: update checkJoinStatus to check status from validator

### DIFF
--- a/scripts/api_tester.ts
+++ b/scripts/api_tester.ts
@@ -25,6 +25,7 @@ crypto.signObj(data, devAccount.secretKey, devAccount.publicKey)
 fetch(`${ARCHIVER_URL}/totalData`, {
   // fetch(`${ARCHIVER_URL}/cycleinfo`, {
   // fetch(`${ARCHIVER_URL}/receipt`, {
+  // fetch(`${ARCHIVER_URL}/account`, {
   method: 'post',
   body: JSON.stringify(data),
   headers: { 'Content-Type': 'application/json' },

--- a/scripts/get_tx_receipt.ts
+++ b/scripts/get_tx_receipt.ts
@@ -16,6 +16,7 @@ const devAccount = {
 const ARCHIVER_URL = `http://127.0.0.1:4000`
 
 const txId = ''
+const timestamp = 0
 const full_receipt = false
 
 const runProgram = async (): Promise<void> => {
@@ -26,6 +27,7 @@ const runProgram = async (): Promise<void> => {
   for (const node of nodeList) {
     const data: any = {
       txId,
+      timestamp,
       full_receipt,
     }
     crypto.signObj(data, devAccount.secretKey, devAccount.publicKey)

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -181,7 +181,12 @@ const isReceiptRobust = async (
           `'fullReceiptResult ${receipt.tx.txId} , ${receipt.cycle}, ${receipt.tx.timestamp}`,
           fullReceiptResult
         )
-      if (!fullReceiptResult || !fullReceiptResult.receipt) continue
+      if (!fullReceiptResult || !fullReceiptResult.receipt) {
+        Logger.mainLogger.error(
+          `Got fullReceiptResult null from robustQuery node for ${receipt.tx.txId} , ${receipt.cycle}, ${receipt.tx.timestamp}`
+        )
+        continue
+      }
       const fullReceipt = fullReceiptResult.receipt as Receipt.ArchiverReceipt
       if (
         isReceiptEqual(fullReceipt.appliedReceipt, robustQueryReceipt) &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,14 +121,13 @@ async function start(): Promise<void> {
       let isJoined = false
       let firstTime = true
       const cycleDuration = Cycles.currentCycleDuration
-      const checkFromConsensor = true
       do {
         try {
           // Get active nodes from Archiver
           const nodeList = NodeList.getActiveList()
 
           // try to join the network
-          isJoined = await Data.joinNetwork(nodeList, firstTime, checkFromConsensor)
+          isJoined = await Data.joinNetwork(nodeList, firstTime)
         } catch (err: unknown) {
           Logger.mainLogger.error('Error while joining network:')
           Logger.mainLogger.error(err as Error)


### PR DESCRIPTION
https://linear.app/shm/issue/BLUE-9/check-archiver-join-status-using-the-joinedarchiver-endpoint

Summary:
Update checkJoinStatus function now verifies its joining status by querying the `/joinedArchiver` endpoint on some(min (activenodes.length, 5)) randomly selected active nodes and confirms its status based on the majority response.