### PR TITLE
Add cycle record data cache

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -330,7 +330,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       return
     }
     if (count > MAX_CYCLES_PER_REQUEST) count = MAX_CYCLES_PER_REQUEST
-    const cycleInfo = await CycleDB.queryLatestCycleRecords(count)
+    const cycleInfo = await Cycles.getLatestCycleRecords(count)
     const res = Crypto.sign({
       cycleInfo,
     })

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -51,6 +51,9 @@ export interface Config {
     MAX_CYCLES_PER_REQUEST: number
     MAX_BETWEEN_CYCLES_PER_REQUEST: number
   }
+  cycleRecordsCache: {
+    enabled: boolean
+  }
 }
 
 let config: Config = {
@@ -101,6 +104,9 @@ let config: Config = {
     MAX_CYCLES_PER_REQUEST: 100,
     MAX_BETWEEN_CYCLES_PER_REQUEST: 100,
   },
+  cycleRecordsCache: {
+    enabled: false,
+  }
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -16,7 +16,7 @@ import * as Logger from '../Logger'
 import { nestedCountersInstance } from '../profiler/nestedCounters'
 import { profilerInstance } from '../profiler/profiler'
 import { getCurrentCycleCounter, shardValuesByCycle, computeCycleMarker } from './Cycles'
-import { bulkInsertCycles, Cycle as DbCycle, queryCycleByMarker, updateCycle } from '../dbstore/cycles'
+import { bulkInsertCycles, queryCycleByMarker, updateCycle } from '../dbstore/cycles'
 import * as State from '../State'
 import * as Utils from '../Utils'
 import { DataType, GossipData, adjacentArchivers, sendDataToAdjacentArchivers, TxData } from './GossipData'
@@ -28,6 +28,7 @@ import ShardFunction from '../ShardFunctions'
 import { ConsensusNodeInfo } from '../NodeList'
 import { verifyAccountHash } from '../shardeum/calculateAccountHash'
 import { verifyAppReceiptData } from '../shardeum/verifyAppReceiptData'
+import { Cycle as DbCycle } from '../dbstore/types'
 
 export let storingAccountData = false
 const processedReceiptsMap: Map<string, number> = new Map()

--- a/src/cache/cycleRecordsCache.ts
+++ b/src/cache/cycleRecordsCache.ts
@@ -1,0 +1,50 @@
+import { P2P } from '@shardus/types'
+import { config } from '../Config'
+import { queryLatestCycleRecords } from '../dbstore/cycles'
+
+let cachedCycleRecords: P2P.CycleCreatorTypes.CycleData[] = []
+let lastCacheUpdateFromDBRunning = false
+
+async function updateCacheFromDB(): Promise<void> {
+  if (lastCacheUpdateFromDBRunning) {
+    return
+  }
+
+  lastCacheUpdateFromDBRunning = true
+
+  try {
+    cachedCycleRecords = await queryLatestCycleRecords(config.REQUEST_LIMIT.MAX_CYCLES_PER_REQUEST)
+  } catch (error) {
+    console.log('Error updating latest cache: ', error)
+  } finally {
+    lastCacheUpdateFromDBRunning = false
+  }
+}
+
+export async function addCyclesToCache(cycles: P2P.CycleCreatorTypes.CycleData[]): Promise<void> {
+  cycles.sort((a, b) => a.counter - b.counter);
+  
+  if (cachedCycleRecords.length === 0) {
+    await updateCacheFromDB()
+  }
+
+  for (const cycle of cycles) {
+    if(cycle.counter < cachedCycleRecords[0].counter) {
+      continue
+    }
+
+    cachedCycleRecords.unshift(cycle)
+  }
+
+  if (cachedCycleRecords.length > config.REQUEST_LIMIT.MAX_CYCLES_PER_REQUEST) {
+    cachedCycleRecords.splice(config.REQUEST_LIMIT.MAX_CYCLES_PER_REQUEST)
+  }
+}
+
+export async function getLatestCycleRecords(count: number): Promise<P2P.CycleCreatorTypes.CycleData[]> {
+  if (cachedCycleRecords.length === 0) {
+    await updateCacheFromDB()
+  }
+
+  return cachedCycleRecords.slice(0, count)
+}

--- a/src/dbstore/cycles.ts
+++ b/src/dbstore/cycles.ts
@@ -1,19 +1,10 @@
 import * as db from './sqlite3storage'
 import { extractValues, extractValuesFromArray } from './sqlite3storage'
-import { P2P, StateManager } from '@shardus/types'
+import { P2P } from '@shardus/types'
 import * as Logger from '../Logger'
 import { config } from '../Config'
 import { DeSerializeFromJsonString, SerializeToJsonString } from '../utils/serialization'
-
-export interface Cycle {
-  counter: P2P.CycleCreatorTypes.CycleData['counter']
-  cycleRecord: P2P.CycleCreatorTypes.CycleData
-  cycleMarker: StateManager.StateMetaDataTypes.CycleMarker
-}
-
-type DbCycle = Cycle & {
-  cycleRecord: string
-}
+import { Cycle, DbCycle } from './types'
 
 export async function insertCycle(cycle: Cycle): Promise<void> {
   try {

--- a/src/dbstore/types.ts
+++ b/src/dbstore/types.ts
@@ -1,0 +1,11 @@
+import { P2P, StateManager } from "@shardus/types"
+
+export interface Cycle {
+    counter: P2P.CycleCreatorTypes.CycleData['counter']
+    cycleRecord: P2P.CycleCreatorTypes.CycleData
+    cycleMarker: StateManager.StateMetaDataTypes.CycleMarker
+}
+
+export type DbCycle = Cycle & {
+    cycleRecord: string
+}


### PR DESCRIPTION
The /cycleinfo/<count> GET endpoint returns a list of the latest count cycleRecords. Every call to the /cycleinfo/<count> endpoint makes a query to the database, resulting in high latency. This PR intends to introduce a cache to store a configurable number of cycle records, controlled by the REQUEST_LIMIT.MAX_CYCLES_PER_REQUEST config variable. The cache is maintained using a Queue data structure. Initially, a query is made to the database to populate the cache with existing cycleRecords. Then, further cycle records are added via the processCycle() function, which adds the latest cycle record to the cache. If the cache exceeds the maximum allowed size, the oldest cycle record is popped from the cache.