### PR TITLE
BLUE-118(feat): Config-patch endpoint added

### DIFF
--- a/scripts/update_config.ts
+++ b/scripts/update_config.ts
@@ -1,0 +1,50 @@
+import axios from 'axios'
+import { join } from 'path'
+import { Utils } from '@shardus/types'
+import * as crypto from '@shardus/crypto-utils'
+import { config, overrideDefaultConfig } from '../src/Config'
+
+const configFile = join(process.cwd(), 'archiver-config.json')
+overrideDefaultConfig(configFile)
+
+crypto.init(config.ARCHIVER_HASH_KEY)
+
+const DEV_KEYS = {
+  pk: config.ARCHIVER_PUBLIC_KEY,
+  sk: config.ARCHIVER_SECRET_KEY,
+}
+
+function sign<T>(obj: T, sk: string, pk: string): T & any {
+  const objCopy = JSON.parse(crypto.stringify(obj))
+  crypto.signObj(objCopy, sk, pk)
+  return objCopy
+}
+
+function createSignature(data: any, pk: string, sk: string): any {
+  return sign({ ...data }, sk, pk)
+}
+
+const UPDATE_CONFIG = {
+  /* Add Config properties that need to be updated here */
+  VERBOSE: true,
+  RATE_LIMIT: 200,
+}
+
+const INPUT = Utils.safeStringify(createSignature(UPDATE_CONFIG, DEV_KEYS.pk, DEV_KEYS.sk))
+
+axios
+  .patch('http://127.0.0.1:4000/set-config', INPUT, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  .then((response) => {
+    console.log(response.data)
+  })
+  .catch((error) => {
+    if (error.response) {
+      console.error(error.response)
+    } else {
+      console.error(error.message)
+    }
+  })

--- a/src/API.ts
+++ b/src/API.ts
@@ -925,6 +925,10 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     reply.send(res)
   })
 
+  /**
+   * This endpoint is used to update the archiver config.
+   * @script A test script to hit this endpoint is available at `scripts/update_config.ts`
+   */
   server.patch(
     '/set-config',
     {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -252,6 +252,7 @@ export function updateConfig(newConfig: Partial<Config>): Config {
       )
   }
   config = merge(config, newConfig)
+  Logger.mainLogger.info('Updated Archiver Config:', config)
   return config
 }
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -242,4 +242,14 @@ export async function overrideDefaultConfig(file: string): Promise<void> {
   }
 }
 
+export function updateConfig(newConfig: Partial<Config>): Config {
+  for (const key in newConfig) {
+    if (newConfig[key] === 'true') newConfig[key] = true
+    if (newConfig[key] === 'false') newConfig[key] = false
+    if (!Number.isNaN(Number(newConfig[key]))) newConfig[key] = Number(newConfig[key])
+  }
+  config = merge(config, newConfig)
+  return config
+}
+
 export { config }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -247,8 +247,8 @@ export function updateConfig(newConfig: Partial<Config>): Config {
     if (newConfig[key] === 'true') newConfig[key] = true
     else if (newConfig[key] === 'false') newConfig[key] = false
     else if (typeof newConfig[key] !== 'boolean' && !Number.isNaN(Number(newConfig[key])))
-      newConfig[key] = Number(newConfig[key])}
-  
+      newConfig[key] = Number(newConfig[key])
+  }
   config = merge(config, newConfig)
   return config
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -245,9 +245,10 @@ export async function overrideDefaultConfig(file: string): Promise<void> {
 export function updateConfig(newConfig: Partial<Config>): Config {
   for (const key in newConfig) {
     if (newConfig[key] === 'true') newConfig[key] = true
-    if (newConfig[key] === 'false') newConfig[key] = false
-    if (!Number.isNaN(Number(newConfig[key]))) newConfig[key] = Number(newConfig[key])
-  }
+    else if (newConfig[key] === 'false') newConfig[key] = false
+    else if (typeof newConfig[key] !== 'boolean' && !Number.isNaN(Number(newConfig[key])))
+      newConfig[key] = Number(newConfig[key])}
+  
   config = merge(config, newConfig)
   return config
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -244,10 +244,12 @@ export async function overrideDefaultConfig(file: string): Promise<void> {
 
 export function updateConfig(newConfig: Partial<Config>): Config {
   for (const key in newConfig) {
-    if (newConfig[key] === 'true') newConfig[key] = true
-    else if (newConfig[key] === 'false') newConfig[key] = false
-    else if (typeof newConfig[key] !== 'boolean' && !Number.isNaN(Number(newConfig[key])))
-      newConfig[key] = Number(newConfig[key])
+    if (typeof newConfig[key] !== typeof config[key])
+      throw new Error(
+        `Value with incorrect type passed to update the Archiver Config: ${key}:${
+          newConfig[key]
+        } of type ${typeof newConfig[key]}`
+      )
   }
   config = merge(config, newConfig)
   return config

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -17,7 +17,7 @@ import { ChangeSquasher, parse, totalNodeCount, activeNodeCount, applyNodeListCh
 import * as State from '../State'
 import * as P2P from '../P2P'
 import * as Utils from '../Utils'
-import { config } from '../Config'
+import { config, updateConfig } from '../Config'
 import { P2P as P2PTypes } from '@shardus/types'
 import * as Logger from '../Logger'
 import { nestedCountersInstance } from '../profiler/nestedCounters'
@@ -558,6 +558,12 @@ async function getConsensusRadius(): Promise<number> {
   if (tallyItem && tallyItem.value && tallyItem.value.config) {
     nodesPerConsensusGroup = tallyItem.value.config.sharding.nodesPerConsensusGroup
     nodesPerEdge = tallyItem.value.config.sharding.nodesPerEdge
+    const devPublicKeys = tallyItem.value.config.debug.devPublicKeys
+    const updateConfigProps = {
+      newPOQReceipt: tallyItem.value.config.stateManager.useNewPOQ,
+      DevPublicKey: Object.keys(devPublicKeys).find((key) => devPublicKeys[key] === 3),
+    }
+    updateConfig(updateConfigProps)
     // Upgrading consensus size to an odd number
     if (nodesPerConsensusGroup % 2 === 0) nodesPerConsensusGroup++
     const consensusRadius = Math.floor((nodesPerConsensusGroup - 1) / 2)

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -558,9 +558,9 @@ async function getConsensusRadius(): Promise<number> {
   if (tallyItem && tallyItem.value && tallyItem.value.config) {
     nodesPerConsensusGroup = tallyItem.value.config.sharding.nodesPerConsensusGroup
     nodesPerEdge = tallyItem.value.config.sharding.nodesPerEdge
-    const devPublicKeys = tallyItem.value.config.debug.devPublicKeys
+    const devPublicKeys = tallyItem.value.config.devPublicKeys
     const updateConfigProps = {
-      newPOQReceipt: tallyItem.value.config.stateManager.useNewPOQ,
+      newPOQReceipt: tallyItem.value.config.useNewPOQ,
       DevPublicKey: Object.keys(devPublicKeys).find((key) => devPublicKeys[key] === 3),
     }
     updateConfig(updateConfigProps)

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -552,14 +552,20 @@ async function syncFromNetworkConfig(): Promise<any> {
     if (tallyItem?.value?.config) {
       // Updating the Archiver Config as per the latest Network Config
       const devPublicKeys = tallyItem.value.config?.devPublicKeys
-      const updateConfigProps = {
-        newPOQReceipt: tallyItem.value.config?.useNewPOQ,
-        DevPublicKey:
-          devPublicKeys && Object.keys(devPublicKeys).length >= 3
-            ? Object.keys(devPublicKeys).find((key) => devPublicKeys[key] === 3)
-            : '',
-      }
-      updateConfig(updateConfigProps)
+      const devPublicKey = devPublicKeys && Object.keys(devPublicKeys).length >= 3 && devPublicKeys[3]
+      const newPOQReceipt = tallyItem.value.config?.useNewPOQ
+      if (
+        devPublicKey &&
+        typeof devPublicKey === typeof config.DevPublicKey &&
+        devPublicKey !== config.DevPublicKey
+      )
+        updateConfig({ DevPublicKey: devPublicKey })
+      if (
+        newPOQReceipt !== null &&
+        typeof newPOQReceipt === typeof config.newPOQReceipt &&
+        newPOQReceipt !== config.newPOQReceipt
+      )
+        updateConfig({ newPOQReceipt })
       return tallyItem
     }
     return null
@@ -576,8 +582,8 @@ async function getConsensusRadius(): Promise<number> {
   const tallyItem = await syncFromNetworkConfig()
   // Check if a consensus was reached
   if (tallyItem?.value?.config) {
-    nodesPerEdge = tallyItem.value.config.sharding.nodesPerEdge
-    nodesPerConsensusGroup = tallyItem.value.config.sharding.nodesPerConsensusGroup
+    nodesPerEdge = tallyItem.value.config.sharding?.nodesPerEdge
+    nodesPerConsensusGroup = tallyItem.value.config?.sharding.nodesPerConsensusGroup
 
     if (!Number.isInteger(nodesPerConsensusGroup) || nodesPerConsensusGroup <= 0) {
       Logger.mainLogger.error('nodesPerConsensusGroup is not a valid number:', nodesPerConsensusGroup)

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -552,7 +552,10 @@ async function syncFromNetworkConfig(): Promise<any> {
     if (tallyItem?.value?.config) {
       // Updating the Archiver Config as per the latest Network Config
       const devPublicKeys = tallyItem.value.config?.devPublicKeys
-      const devPublicKey = devPublicKeys && Object.keys(devPublicKeys).length >= 3 && devPublicKeys[3]
+      const devPublicKey =
+        devPublicKeys &&
+        Object.keys(devPublicKeys).length >= 3 &&
+        Object.keys(devPublicKeys).find((key) => devPublicKeys[key] === 3)
       const newPOQReceipt = tallyItem.value.config?.useNewPOQ
       if (
         devPublicKey &&
@@ -561,7 +564,7 @@ async function syncFromNetworkConfig(): Promise<any> {
       )
         updateConfig({ DevPublicKey: devPublicKey })
       if (
-        newPOQReceipt !== null &&
+        !Utils.isUndefined(newPOQReceipt) &&
         typeof newPOQReceipt === typeof config.newPOQReceipt &&
         newPOQReceipt !== config.newPOQReceipt
       )

--- a/src/ShardFunctions.ts
+++ b/src/ShardFunctions.ts
@@ -52,7 +52,7 @@ class ShardFunctions {
 
     //make sure nodesPerConsenusGroup is an odd number >= 3
     if (nodesPerConsenusGroup % 2 === 0 || nodesPerConsenusGroup < 3) {
-      throw new Error(`nodesPerConsenusGroup:${nodesPerConsenusGroup} must be odd and >= 3`)
+      throw new Error(`nodesPerConsenusGroup: ${nodesPerConsenusGroup} must be odd and >= 3`)
     }
 
     shardGlobals.consensusRadius = Math.floor((nodesPerConsenusGroup - 1) / 2)


### PR DESCRIPTION
### Summary
This PR adds a new endpoint: **`/set-config`** that allows updating the archiver's config on-the-fly.

#### [Linear Task - BLUE-118](https://linear.app/shm/issue/BLUE-118)