### PR TITLE
SYS-343: Introduced two new endpoints, `/is-alive` and `/is-healthy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This is a node that runs as part of the shardus network, with the function of re
 
 To release, just run `npm run release`
 
+## Health Check
+
+GET `/is-alive` this endpoint returns 200 if the server is running.
+GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
+
 ## Contributing
 
 Contributions are very welcome! Everyone interacting in our codebases, issue trackers, and any other form of communication, including chat rooms and mailing lists, is expected to follow our [code of conduct](./CODE_OF_CONDUCT.md) so we can all enjoy the effort we put into this project.

--- a/src/routes/healthCheck.ts
+++ b/src/routes/healthCheck.ts
@@ -1,0 +1,14 @@
+import { FastifyPluginCallback } from 'fastify'
+
+export const healthCheckRouter: FastifyPluginCallback = function (fastify, opts, done) {
+  fastify.get('/is-alive', (req, res) => {
+    return res.status(200).send('OK')
+  })
+
+  fastify.get('/is-healthy', (req, res) => {
+    // TODO: Add actual health check logic
+    return res.status(200).send('OK')
+  })
+  
+  done()
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import { loadGlobalAccounts, syncGlobalAccount } from './GlobalAccount'
 import { setShutdownCycleRecord, cycleRecordWithShutDownMode } from './Data/Cycles'
 import { registerRoutes } from './API'
 import { Utils as StringUtils } from '@shardus/types'
+import { healthCheckRouter } from './routes/healthCheck'
 
 const configFile = join(process.cwd(), 'archiver-config.json')
 let logDir: string
@@ -438,6 +439,7 @@ async function startServer(): Promise<void> {
     timeWindow: 10,
     allowList: ['127.0.0.1', '0.0.0.0'], // Excludes local IPs from rate limits
   })
+  await server.register(healthCheckRouter)
 
   server.addContentTypeParser('application/json', { parseAs: 'string' }, (req, body, done) => {
     try {


### PR DESCRIPTION
Introduced two new endpoints, `/is-alive` and `/is-healthy`, for health checks. Documentation updated accordingly.