### PR TITLE
BLUE-254: /totalData DB queries optimised

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -841,11 +841,14 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       reply.send({ success: false, error: result.error })
       return
     }
-    const totalCycles = await CycleDB.queryCyleCount()
-    const totalAccounts = await AccountDB.queryAccountCount()
-    const totalTransactions = await TransactionDB.queryTransactionCount()
-    const totalReceipts = await ReceiptDB.queryReceiptCount()
-    const totalOriginalTxs = await OriginalTxDB.queryOriginalTxDataCount()
+    const [totalCycles, totalAccounts, totalReceipts, totalTransactions, totalOriginalTxs] =
+      await Promise.all([
+        CycleDB.queryCyleCount(),
+        AccountDB.queryAccountCount(),
+        ReceiptDB.queryReceiptCount(),
+        TransactionDB.queryTransactionCount(),
+        OriginalTxDB.queryOriginalTxDataCount(),
+      ])
     reply.send(
       Crypto.sign({ totalCycles, totalAccounts, totalTransactions, totalReceipts, totalOriginalTxs })
     )

--- a/src/dbstore/accounts.ts
+++ b/src/dbstore/accounts.ts
@@ -134,7 +134,7 @@ export async function queryAccounts(skip = 0, limit = 10000): Promise<AccountsCo
 export async function queryAccountCount(): Promise<number> {
   let accounts
   try {
-    const sql = `SELECT COUNT(*) FROM accounts`
+    const sql = `SELECT COUNT(timestamp) FROM accounts`
     accounts = await db.get(accountDatabase, sql, [])
   } catch (e) {
     Logger.mainLogger.error(e)
@@ -142,7 +142,7 @@ export async function queryAccountCount(): Promise<number> {
   if (config.VERBOSE) {
     Logger.mainLogger.debug('Account count', accounts)
   }
-  if (accounts) accounts = accounts['COUNT(*)']
+  if (accounts) accounts = accounts['COUNT(timestamp)']
   else accounts = 0
   return accounts
 }

--- a/src/dbstore/cycles.ts
+++ b/src/dbstore/cycles.ts
@@ -126,7 +126,7 @@ export async function queryCycleRecordsBetween(
 export async function queryCyleCount(): Promise<number> {
   let cycles
   try {
-    const sql = `SELECT COUNT(*) FROM cycles`
+    const sql = `SELECT COUNT(counter) FROM cycles`
     cycles = await db.get(cycleDatabase, sql, [])
   } catch (e) {
     Logger.mainLogger.error(e)
@@ -134,7 +134,7 @@ export async function queryCyleCount(): Promise<number> {
   if (config.VERBOSE) {
     Logger.mainLogger.debug('Cycle count', cycles)
   }
-  if (cycles) cycles = cycles['COUNT(*)']
+  if (cycles) cycles = cycles['COUNT(counter)']
   else cycles = 0
   return cycles
 }

--- a/src/dbstore/originalTxsData.ts
+++ b/src/dbstore/originalTxsData.ts
@@ -67,7 +67,7 @@ export async function bulkInsertOriginalTxsData(originalTxsData: OriginalTxData[
 export async function queryOriginalTxDataCount(startCycle?: number, endCycle?: number): Promise<number> {
   let originalTxsData
   try {
-    let sql = `SELECT COUNT(*) FROM originalTxsData`
+    let sql = `SELECT COUNT(timestamp) FROM originalTxsData`
     const values: number[] = []
     if (startCycle && endCycle) {
       sql += ` WHERE cycle BETWEEN ? AND ?`
@@ -80,7 +80,7 @@ export async function queryOriginalTxDataCount(startCycle?: number, endCycle?: n
   if (config.VERBOSE) {
     Logger.mainLogger.debug('OriginalTxData count', originalTxsData)
   }
-  return originalTxsData['COUNT(*)'] || 0
+  return originalTxsData['COUNT(timestamp)'] || 0
 }
 
 export async function queryOriginalTxsData(

--- a/src/dbstore/receipts.ts
+++ b/src/dbstore/receipts.ts
@@ -198,7 +198,7 @@ export async function queryReceipts(skip = 0, limit = 10000): Promise<Receipt[]>
 export async function queryReceiptCount(): Promise<number> {
   let receipts
   try {
-    const sql = `SELECT COUNT(*) FROM receipts`
+    const sql = `SELECT COUNT(timestamp) FROM receipts`
     receipts = await db.get(receiptDatabase, sql, [])
   } catch (e) {
     Logger.mainLogger.error(e)
@@ -206,7 +206,7 @@ export async function queryReceiptCount(): Promise<number> {
   if (config.VERBOSE) {
     Logger.mainLogger.debug('Receipt count', receipts)
   }
-  if (receipts) receipts = receipts['COUNT(*)']
+  if (receipts) receipts = receipts['COUNT(timestamp)']
   else receipts = 0
   return receipts
 }

--- a/src/dbstore/transactions.ts
+++ b/src/dbstore/transactions.ts
@@ -150,7 +150,7 @@ export async function queryTransactions(skip = 0, limit = 10000): Promise<Transa
 export async function queryTransactionCount(): Promise<number> {
   let transactions
   try {
-    const sql = `SELECT COUNT(*) FROM transactions`
+    const sql = `SELECT COUNT(timestamp) FROM transactions`
     transactions = await db.get(transactionDatabase, sql, [])
   } catch (e) {
     Logger.mainLogger.error(e)
@@ -158,7 +158,7 @@ export async function queryTransactionCount(): Promise<number> {
   if (config.VERBOSE) {
     Logger.mainLogger.debug('Transaction count', transactions)
   }
-  if (transactions) transactions = transactions['COUNT(*)']
+  if (transactions) transactions = transactions['COUNT(timestamp)']
   else transactions = 0
   return transactions
 }


### PR DESCRIPTION
### Summary
This PR tweaks the **`COUNT`** query across the 5 databases in the Archiver to serve data to the **`/totalData`** API. The goal is to optimise the API, making it as lightweight as possible in preparation for the upcoming alerting system.

### **[Linear Task](https://linear.app/shm/issue/BLUE-254/totaldata-endpoint-upgrade)**