### PR TITLE
SHARD-1063 : Potential DoS of archiver-server during network restoration via get_account_data_archiver call

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -933,6 +933,13 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       reply.send({ success: false, error: result.error })
       return
     }
+    if (payload.maxRecords > config.maxRecordsPerRequest) {
+      reply.send({
+        success: false,
+        error: 'AccountBucket Size has exceeded the max records allowed per request',
+      })
+      return
+    }
     const data = await AccountDataProvider.provideAccountDataRequest(payload)
     // Logger.mainLogger.debug('Account Data result', data)
     const res = Crypto.sign({

--- a/src/API.ts
+++ b/src/API.ts
@@ -936,7 +936,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     if (payload.maxRecords > config.maxRecordsPerRequest) {
       reply.send({
         success: false,
-        error: 'AccountBucket Size has exceeded the max records allowed per request',
+        error: `AccountBucket size has exceeded the max records allowed per request. Allowed: ${config.maxRecordsPerRequest}`,
       })
       return
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -196,7 +196,7 @@ let config: Config = {
   disableOffloadReceipt: false,
   disableOffloadReceiptForGlobalModification: true,
   restoreNGTsFromSnapshot: false,
-  maxRecordsPerRequest: 1000, 
+  maxRecordsPerRequest: 200, 
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -102,6 +102,7 @@ export interface Config {
   disableOffloadReceipt: boolean // To disable offloading of receipts globally
   disableOffloadReceiptForGlobalModification: boolean // To disable offloading of receipts for global modifications receipts
   restoreNGTsFromSnapshot: boolean // To restore NGTs from snapshot
+  maxRecordsPerRequest: number // this is the equiavlent of the accountBucketSize config variable used by the validators to fetch records from the archiver
 }
 
 let config: Config = {
@@ -195,6 +196,7 @@ let config: Config = {
   disableOffloadReceipt: false,
   disableOffloadReceiptForGlobalModification: true,
   restoreNGTsFromSnapshot: false,
+  maxRecordsPerRequest: 1000, 
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {


### PR DESCRIPTION
linear :  https://linear.app/shm/issue/SHARD-1063/[bug-bounty]-35709-potential-dos-of-archiver-server-during-network

For this task, we have added a limit on the max records that can be requested by the validator using the aforementioned API endpoint. This helps us avoid DoS vulnerabilities that may arise during the restoration of the network. If a malicious node does request for records in high magnitude, their request is rejected. 