### PR TITLE
SHARD-1203: Update requiredMajorityVotesPercentage to 2/3 from 60

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -184,7 +184,7 @@ let config: Config = {
   stopGossipTxData: false,
   usePOQo: true,
   requiredVotesPercentage: 2 / 3,
-  requiredMajorityVotesPercentage: 60,
+  requiredMajorityVotesPercentage: 2 / 3,
   maxCyclesShardDataToKeep: 10,
   configChangeMaxCyclesToKeep: 5,
   configChangeMaxChangesToKeep: 1000,


### PR DESCRIPTION
Linear: https://linear.app/shm/issue/SHARD-1203

Summary: Set `requiredMajorityVotesPercentage` to 66.7% (2/3) for global transactions to align with regular transactions.