### PR TITLE
chore: Removed duplicate import from 'path'

### DIFF
--- a/scripts/verify_account_hash.ts
+++ b/scripts/verify_account_hash.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs'
-import { resolve } from 'path'
-import { join } from 'path'
+import { resolve, join } from 'path'
 import { overrideDefaultConfig, config } from '../src/Config'
 import * as Crypto from '../src/Crypto'
 import * as dbstore from '../src/dbstore'


### PR DESCRIPTION
Merged `resolve` and `join` into a single import from 'path'. The code is now a bit cleaner.