### PR TITLE
fix: Fix in function name (queryCyleCount → queryCycleCount)

### DIFF
--- a/scripts/archiver_data_patcher.ts
+++ b/scripts/archiver_data_patcher.ts
@@ -166,7 +166,7 @@ const runProgram = async (): Promise<void> => {
     }
   }
 
-  const totalCycles = await CycleDB.queryCyleCount()
+  const totalCycles = await CycleDB.queryCycleCount()
   const totalAccounts = await AccountDB.queryAccountCount()
   const totalTransactions = await TransactionDB.queryTransactionCount()
   const totalReceipts = await ReceiptDB.queryReceiptCount()


### PR DESCRIPTION

There was a typo in the function name:  

```js
const totalCycles = await CycleDB.queryCyleCount()
```  

The method doesn't exist, which causes a `TypeError`. It should be:  

```js
const totalCycles = await CycleDB.queryCycleCount()
```  

Now, the code runs correctly without errors.