### PR TITLE
SHARD-1926: compare afterStateHash in receipt verification

### DIFF
--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -32,6 +32,23 @@ export enum InternalTXType {
   TransferFromSecureAccount = 13,
 }
 
+/**
+ * Verifies the account hash in a global transaction receipt
+ *
+ * This function validates that the account hashes in a receipt match the calculated
+ * hashes of the account data. It checks:
+ * 1. If the receipt passes schema validation
+ * 2. If the receipt is a GlobalTxReceipt, it delegates to verifyGlobalTxAccountChange
+ * 3. Otherwise, it verifies:
+ *    - Account IDs, before and after state hashes have matching lengths
+ *    - Each account in afterStates has a matching ID from the receipt
+ *    - The calculated hash of each account matches the expected hash in the receipt
+ *
+ * @param receipt - The transaction receipt to verify
+ * @param failedReasons - Array to collect failure reasons if verification fails
+ * @param nestedCounterMessages - Array to collect counter messages for metrics
+ * @returns boolean - True if verification passes, false otherwise
+ */
 export const verifyGlobalTxAccountChange = (
   receipt: ArchiverReceipt | Receipt,
   failedReasons = [],
@@ -70,6 +87,7 @@ export const verifyGlobalTxAccountChange = (
         }
       }
       for (const account of receipt.afterStates) {
+        // TODO : can be optimized by using only one find operation instead of for loop since we have only afterState for globalModification tx
         if (account.accountId !== signedReceipt.tx.address) {
           failedReasons.push(
             `Unexpected account found in accounts ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
@@ -85,21 +103,22 @@ export const verifyGlobalTxAccountChange = (
         )
         if (!networkAccountBefore || !networkAccountAfter) {
           failedReasons.push(
-            `No network account found in accounts ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
+            `Network account Before or After states not found ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
           )
-          nestedCounterMessages.push(`No network account found in accounts`)
+          nestedCounterMessages.push(`Network account Before or After states not found`)
           return false
         }
-        networkAccountBefore.data.listOfChanges?.push(internalTx.change)
-        networkAccountBefore.data.timestamp = signedReceipt.tx.when
+
+        // Get the hash from afterState array entry i.e the network account after state hash
         const expectedAccountHash = networkAccountAfter.hash
-        console.dir(networkAccountBefore, { depth: null })
-        // const calculatedAccountHash = accountSpecificHash(networkAccountBefore.data)
+
+        // Compare the hash from the network account with the afterStateHash in the signed receipt
+        // If they don't match, the transaction receipt is invalid
         if (expectedAccountHash !== signedReceipt.tx.afterStateHash) {
           failedReasons.push(
-            `Account hash does not match in globalModification tx - ${networkAccountAfter.accountId} , ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
+            `Account afterStateHash does not match in globalModification tx - ${networkAccountAfter.accountId} , ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
           )
-          nestedCounterMessages.push(`Account hash does not match in globalModification tx`)
+          nestedCounterMessages.push(`Account afterStateHash does not match in globalModification tx`)
           return false
         }
       }

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -94,8 +94,8 @@ export const verifyGlobalTxAccountChange = (
         networkAccountBefore.data.timestamp = signedReceipt.tx.when
         const expectedAccountHash = networkAccountAfter.hash
         console.dir(networkAccountBefore, { depth: null })
-        const calculatedAccountHash = accountSpecificHash(networkAccountBefore.data)
-        if (expectedAccountHash !== calculatedAccountHash) {
+        // const calculatedAccountHash = accountSpecificHash(networkAccountBefore.data)
+        if (expectedAccountHash !== signedReceipt.tx.afterStateHash) {
           failedReasons.push(
             `Account hash does not match in globalModification tx - ${networkAccountAfter.accountId} , ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
           )

--- a/test/unit/src/shardeum/verifyGlobalTxReceipt.test.ts
+++ b/test/unit/src/shardeum/verifyGlobalTxReceipt.test.ts
@@ -384,9 +384,9 @@ describe('verifyGlobalTxAccountChange', () => {
 
       expect(result).toBe(false)
       expect(failedReasons).toContain(
-        `No network account found in accounts ${mockReceipt.tx.txId} , ${mockReceipt.cycle} , ${mockReceipt.tx.timestamp}`
+        `Network account Before or After states not found ${mockReceipt.tx.txId} , ${mockReceipt.cycle} , ${mockReceipt.tx.timestamp}`
       )
-      expect(nestedCounterMessages).toContain('No network account found in accounts')
+      expect(nestedCounterMessages).toContain('Network account Before or After states not found')
     }
   })
   //new


### PR DESCRIPTION
The global Tx receipt verification flow on the archiver side now fetches the afterStateHash from the signed receipt and then compares it with the entry from the afterStates array 

Relevant PRs :

https://github.com/shardeum/shardeum/pull/359
https://github.com/shardeum/core/pull/411
https://github.com/shardeum/lib-types/pull/34

### 🚨 Summary  
[SHARD-1926 — Malicious Validator Can Modify `txId` in Global Transactions](https://linear.app/shm/issue/SHARD-1926/[bb]-39893-malicious-validator-can-modify-txid-in-global-transactions)

This PR resolves a critical security vulnerability in how the archiver validates Global Transaction Receipts.

Global transactions submitted to the archiver include a `tx` object that is **not cryptographically verified**. As a result, malicious validators can alter the `txId`, `timestamp`, and even the `afterStates` without invalidating the receipt.

This flaw enables two types of attacks:
1. **Transaction censorship** — by hijacking a `txId`, future valid submissions are rejected.
2. **State corruption** — by modifying `afterStates`, attackers can inject or alter accounts arbitrarily.

---

### ⚠️ Root Cause  
- The `verifyAppliedReceiptSignatures()` function extracts the `tx` object from `receipt.signedReceipt`, but **does not validate its integrity**.
- Unlike `beforeStates` and `afterStates`, which are separately validated in `verifyGlobalTxAccountChange()`, the core `tx` payload—including `txId` and other metadata—is trusted without recomputation or comparison.
- The current logic assumes that the signed receipt's internal `tx` is trustworthy, without enforcing consistency with the actual signature.

