### PR TITLE
SHARD-1960: use streams for axios requests as well

### DIFF
--- a/src/utils/customHttpFunctions.ts
+++ b/src/utils/customHttpFunctions.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosProgressEvent, AxiosRequestConfig, CancelTok
 import { config } from '../Config'
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch'
 import { Utils } from '@shardeum-foundation/lib-types'
+import { PassThrough } from 'stream'
 
 /**
  * A custom fetch function with a max response body size limit.
@@ -26,20 +27,14 @@ export async function customFetch(
  * @returns Custom axios instance
  */
 export function customAxios(maxBytes?: number, axiosConfig: AxiosRequestConfig = {}): AxiosInstance {
-  // Use the provided maxBytes or fall back to config.maxResponseSize
   const downloadLimit = maxBytes ?? config.maxResponseSize
-
+  const userRequestedType = axiosConfig.responseType ?? 'json'
+  axiosConfig.responseType = 'stream'
   const instance = axios.create({
     ...axiosConfig,
-    maxContentLength: downloadLimit,
-    maxBodyLength: downloadLimit,
-    // Add responseType for better handling
-    responseType: 'arraybuffer',
-    // Don't automatically reject on error status codes
     validateStatus: () => true,
   })
 
-  // Add request interceptor to add a cancel token
   instance.interceptors.request.use((request) => {
     const source = axios.CancelToken.source()
     request.cancelToken = source.token
@@ -47,71 +42,75 @@ export function customAxios(maxBytes?: number, axiosConfig: AxiosRequestConfig =
     return request
   })
 
-  // Add response interceptor to check size
   instance.interceptors.response.use(
-    (response) => {
-      // Check size for different response types
-      if (response.data) {
-        let dataSize = 0
-
-        if (response.data instanceof ArrayBuffer) {
-          dataSize = response.data.byteLength
-        } else if (typeof response.data === 'string') {
-          dataSize = response.data.length
-        } else if (Buffer.isBuffer(response.data)) {
-          dataSize = response.data.length
-        } else if (typeof response.data === 'object') {
-          // For JSON responses
-          dataSize = Utils.safeStringify(response.data).length
-        }
-
-        if (dataSize > downloadLimit) {
-          throw new Error(`Response size of ${dataSize} bytes exceeds limit of ${downloadLimit} bytes`)
-        }
-      }
-
-      // Also check Content-Length header if available
+    async (response) => {
       const contentLength = parseInt(response.headers['content-length'] || '0', 10)
       if (contentLength > 0 && contentLength > downloadLimit) {
-        throw new Error(
-          `Response content length ${contentLength} bytes exceeds limit of ${downloadLimit} bytes`
+        ;(response.config as any)._cancelSource?.cancel(
+          `Response content-length ${contentLength} exceeds limit of ${downloadLimit}`
         )
+        throw new Error(`Response size exceeds limit of ${downloadLimit} bytes`)
       }
 
-      return response
+      const stream = response.data
+      let totalBytes = 0
+      const chunks: Buffer[] = []
+
+      return new Promise((resolve, reject) => {
+        stream.on('data', (chunk: Buffer) => {
+          totalBytes += chunk.length
+          if (totalBytes > downloadLimit) {
+            stream.destroy(
+              new Error(`Response size exceeds limit of ${downloadLimit} bytes`)
+            )
+            return
+          }
+          chunks.push(chunk)
+        })
+
+        stream.on('end', () => {
+          const fullBuffer = Buffer.concat(chunks)
+
+          switch (userRequestedType) {
+            case 'stream': { // If user truly wants a stream, we can either:
+              const pass = new PassThrough()
+              pass.end(fullBuffer)
+              response.data = pass
+              break
+            }
+
+            case 'arraybuffer':
+              response.data = fullBuffer
+              break
+
+            case 'json':
+            default:
+              try {
+                response.data = Utils.safeJsonParse(fullBuffer.toString('utf8'))
+              } catch (err: any) {
+                return reject(
+                  new Error(`Failed to parse JSON (size: ${fullBuffer.length} bytes): ${err.message}`)
+                )
+              }
+              break
+          }
+
+          resolve(response)
+        })
+
+        stream.on('error', (err: Error) => {
+          reject(err)
+        })
+      })
     },
     (error) => {
+      // Distinguish cancellation due to size from other errors
       if (axios.isCancel(error)) {
         throw new Error(`Response size exceeds limit of ${downloadLimit} bytes`)
       }
-
-      if (
-        error.message &&
-        (error.message.includes('maxContentLength') ||
-          error.message.includes('maxBodyLength') ||
-          error.message.includes('socket hang up'))
-      ) {
-        throw new Error(`Response size exceeds limit of ${downloadLimit} bytes`)
-      }
-
       throw error
     }
   )
-
-  // Handle download progress
-  instance.defaults.onDownloadProgress = (progressEvent: AxiosProgressEvent) => {
-    if (progressEvent.loaded > downloadLimit) {
-      try {
-        const event = progressEvent as unknown as { config?: { _cancelSource?: CancelTokenSource } }
-        if (event.config?._cancelSource?.cancel) {
-          event.config._cancelSource.cancel(`Response size exceeds limit of ${downloadLimit} bytes`)
-        }
-      } catch (err) {
-        // Silently handle any errors with the cancellation
-        console.error('Error during request cancellation:', err)
-      }
-    }
-  }
 
   return instance
 }

--- a/test/unit/src/utils/customHttpFunctions.test.ts
+++ b/test/unit/src/utils/customHttpFunctions.test.ts
@@ -116,7 +116,7 @@ describe('customGot and customFetch', () => {
 
     describe('customAxios', () => {
         test('should successfully fetch a response under the size limit', async () => {
-            const response = await customAxios().get(`${serverUrl}/small-data`)
+            const response = await customAxios(undefined, {responseType: 'arraybuffer'}).get(`${serverUrl}/small-data`)
             expect(response.status).toBe(200)
             expect(response.data.length).toBeGreaterThan(5 * 1024 - 100)
         }, 10000)


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Implement streaming for Axios requests to handle large responses.

- Add response type handling for streams, array buffers, and JSON.

- Update unit tests to verify new Axios streaming functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customHttpFunctions.ts</strong><dd><code>Implement streaming and response type handling in Axios</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/utils/customHttpFunctions.ts

<li>Implement streaming for Axios responses.<br> <li> Add response type handling for streams, array buffers, and JSON.<br> <li> Remove previous size checks and progress handling.<br> <li> Use <code>PassThrough</code> stream for response data.


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/166/files#diff-f3e43a9d6bd3a5790d8e9312d0bdf49c7758ac3e89e74345f125ec68c80b603b">+58/-59</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customHttpFunctions.test.ts</strong><dd><code>Update Axios tests for new streaming functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/utils/customHttpFunctions.test.ts

<li>Update test to specify response type as array buffer.<br> <li> Verify Axios response handling under size limit.


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/166/files#diff-6a1fdc532d6d5c60356fcf51af8528e17b405767236995b4cc03e28627570fa1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>