### PR TITLE
SHARD-2235 : Attack vector 2 - shard 2216

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,6 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
+  allowInitNetworkReceipts: boolean
 }
 
 let config: Config = {
@@ -285,6 +286,7 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
+  allowInitNetworkReceipts: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/shardeum/calculateAccountHash.ts
+++ b/src/shardeum/calculateAccountHash.ts
@@ -60,30 +60,31 @@ export const accountSpecificHash = (account: any): string => {
   return hash
 }
 
-export const verifyAccountHash = (
+/**
+ * Verifies the validity of account changes in a non-global transaction by comparing
+ * the provided receipt's account state hashes and account data.
+ *
+ * @param receipt - The receipt object containing transaction details and state information.
+ *                  It can be of type `ArchiverReceipt` or `Receipt`.
+ * @param failedReasons - An array to collect detailed error messages if the verification fails.
+ *                        Defaults to an empty array.
+ * @param nestedCounterMessages - An array to collect high-level error messages for nested counters
+ *                                if the verification fails. Defaults to an empty array.
+ * @returns A boolean indicating whether the account changes in the receipt are valid.
+ *
+ * ### Validation Steps:
+ * 1. Ensures the number of modified accounts matches the number of after-state hashes.
+ * 2. Ensures the number of before-state hashes matches the number of after-state hashes.
+ * 3. Iterates through each account ID in the receipt:
+ *    - Verifies that the account exists in the `afterStates` of the receipt.
+ *    - Calculates the account-specific hash and compares it with the expected hash.
+ */
+function verifyNonGlobalTxAccountChange(
   receipt: ArchiverReceipt | Receipt,
   failedReasons = [],
   nestedCounterMessages = []
-): boolean => {
+): boolean {
   try {
-    let globalReceiptValidationErrors // This is used to store the validation errors of the globalTxReceipt
-    try {
-      globalReceiptValidationErrors = verifyPayload(AJVSchemaEnum.GlobalTxReceipt, receipt?.signedReceipt)
-    } catch (error) {
-      globalReceiptValidationErrors = true
-      failedReasons.push(
-        `Invalid Global Tx Receipt error: ${error}. txId ${receipt.tx.txId} , cycle ${receipt.cycle} , timestamp ${receipt.tx.timestamp}`
-      )
-      nestedCounterMessages.push(
-        `Invalid Global Tx Receipt error: ${error}. txId ${receipt.tx.txId} , cycle ${receipt.cycle} , timestamp ${receipt.tx.timestamp}`
-      )
-      return false
-    }
-    if (!globalReceiptValidationErrors) {
-      const result = verifyGlobalTxAccountChange(receipt, failedReasons, nestedCounterMessages)
-      if (!result) return false
-      return true
-    }
     const signedReceipt = receipt.signedReceipt as SignedReceipt
     const { accountIDs, afterStateHashes, beforeStateHashes } = signedReceipt.proposal
     if (accountIDs.length !== afterStateHashes.length) {
@@ -122,6 +123,57 @@ export const verifyAccountHash = (
         return false
       }
     }
+    return true
+  } catch (error) {
+    console.error(`verifyNonGlobalTxAccountChange error`, error)
+    failedReasons.push(
+      `Error while verifying non global account change ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}, ${error}`
+    )
+    nestedCounterMessages.push(`Error while verifying non global account change`)
+    return false
+  }
+}
+
+/**
+ * Verifies the account hash for a given receipt. This function validates the receipt
+ * against a schema and checks the account changes based on whether the receipt is global
+ * or non-global. It also collects validation errors and messages for debugging purposes.
+ *
+ * @param receipt - The receipt object to be verified. It can be of type `ArchiverReceipt` or `Receipt`.
+ * @param failedReasons - An optional array to store reasons for validation failure.
+ * @param nestedCounterMessages - An optional array to store nested counter messages for debugging.
+ * @returns A boolean indicating whether the account hash verification was successful.
+ *
+ * @throws Will catch and log any unexpected errors during the verification process.
+ */
+export const verifyAccountHash = (
+  receipt: ArchiverReceipt | Receipt,
+  failedReasons = [],
+  nestedCounterMessages = []
+): boolean => {
+  try {
+    let globalReceiptValidationErrors // This is used to store the validation errors of the globalTxReceipt
+    try {
+      globalReceiptValidationErrors = verifyPayload(AJVSchemaEnum.GlobalTxReceipt, receipt?.signedReceipt)
+    } catch (error) {
+      globalReceiptValidationErrors = true
+      failedReasons.push(
+        `Invalid Global Tx Receipt error: ${error}. txId ${receipt.tx.txId} , cycle ${receipt.cycle} , timestamp ${receipt.tx.timestamp}`
+      )
+      nestedCounterMessages.push(
+        `Invalid Global Tx Receipt error: ${error}. txId ${receipt.tx.txId} , cycle ${receipt.cycle} , timestamp ${receipt.tx.timestamp}`
+      )
+      return false
+    }
+
+    let result: boolean
+    if (!globalReceiptValidationErrors) {
+      result = verifyGlobalTxAccountChange(receipt, failedReasons, nestedCounterMessages)
+    } else {
+      result = verifyNonGlobalTxAccountChange(receipt, failedReasons, nestedCounterMessages)
+    }
+
+    if (!result) return false
     return true
   } catch (e) {
     console.error(`Error in verifyAccountHash`, e)

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -1,6 +1,7 @@
 import { P2P } from '@shardeum-foundation/lib-types'
 import { ArchiverReceipt, Receipt } from '../dbstore/receipts'
 import { accountSpecificHash } from './calculateAccountHash'
+import { config } from '../Config'
 
 // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/shardeum/shardeumTypes.ts#L242
 export interface SetGlobalTxValue {
@@ -58,9 +59,10 @@ export const verifyGlobalTxAccountChange = (
     const signedReceipt = receipt.signedReceipt as P2P.GlobalAccountsTypes.GlobalTxReceipt
     const internalTx = signedReceipt.tx.value as SetGlobalTxValue
 
-    if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+    if (internalTx.internalTXType === InternalTXType.InitNetwork && config.allowInitNetworkReceipts) {
       // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/index.ts#L2334
       // no need to do anything, as it is network account creation
+      config.allowInitNetworkReceipts = false
       return true
     } else if (
       internalTx.internalTXType === InternalTXType.ApplyChangeConfig ||

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -109,12 +109,12 @@ export const verifyGlobalTxAccountChange = (
           return false
         }
 
-        // Get the hash from afterState array entry i.e the network account after state hash
-        const expectedAccountHash = networkAccountAfter.hash
+        // Calculate the afterStateHash
+        const calculatedAfterStateHash = accountSpecificHash(networkAccountAfter.data)
 
         // Compare the hash from the network account with the afterStateHash in the signed receipt
         // If they don't match, the transaction receipt is invalid
-        if (expectedAccountHash !== signedReceipt.tx.afterStateHash) {
+        if (calculatedAfterStateHash !== signedReceipt.tx.afterStateHash) {
           failedReasons.push(
             `Account afterStateHash does not match in globalModification tx - ${networkAccountAfter.accountId} , ${receipt.tx.txId} , ${receipt.cycle} , ${receipt.tx.timestamp}`
           )

--- a/test/unit/src/calculateAccountHash.test.ts
+++ b/test/unit/src/calculateAccountHash.test.ts
@@ -377,8 +377,10 @@ describe('calculateAccountHash', () => {
 
       // THEN it should capture the exception and fail
       expect(result).toBe(false)
-      expect(failedReasons[0]).toContain('Error in verifyAccountHash')
-      expect(nestedCounterMessages[0]).toContain('Error in verifyAccountHash')
+      let errorString =
+        "Error while verifying non global account change test-tx-id , 1 , 12345, TypeError: Cannot destructure property 'accountIDs' of 'signedReceipt.proposal' as it is undefined."
+      expect(failedReasons[0]).toContain(errorString)
+      expect(nestedCounterMessages[0]).toContain('Error while verifying non global account change')
     })
   })
 })


### PR DESCRIPTION
### 🚨 User Description  
[SHARD-2235 — Attack Vector 2 (linked to SHARD-2216)](https://linear.app/shm/issue/SHARD-2235/attack-vector-2-shard-2216)

This PR addresses the second attack vector related to **Global transaction receipts**.

Although the receipt may contain valid signatures and reference a correct `accountId`, a malicious actor can still **arbitrarily change the balances** of the accounts in the receipt. This is possible because:

- The archiver currently **does not recalculate the hash** of the `afterStates` object.
- Instead, it only compares the `afterStateHash` provided in the receipt against the already present hash string.
- **We only recalculate hashes for `beforeStates`**, which is ineffective—since **account mutations rely on `afterStates`**.

#### Problematic Code
The issue originates from this code snippet:
https://github.com/shardeum/archiver/blob/dev/src/shardeum/verifyGlobalTxReceipt.ts#L89C1-L130C6

```ts
const expectedAccountHash = networkAccountAfter.hash

// Compare the hash from the network account with the afterStateHash in the signed receipt
// If they don't match, the transaction receipt is invalid
if (expectedAccountHash !== signedReceipt.tx.afterStateHash) {
```
___

### **Description**
- Introduces `allowInitNetworkReceipts` config flag for initial network setup

- Disables initial network receipts after first use for security

- Refactors and documents account hash verification logic

- Fixes afterStateHash calculation and comparison in global tx verification


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Config.ts</strong><dd><code>Add allowInitNetworkReceipts config flag and default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Config.ts

<li>Adds <code>allowInitNetworkReceipts</code> boolean to config interface and default <br>config<br> <li> Enables initial network receipts by default


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/225/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>calculateAccountHash.ts</strong><dd><code>Refactor and document account hash verification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/calculateAccountHash.ts

<li>Refactors account hash verification into separate function for <br>non-global txs<br> <li> Adds detailed documentation to verification functions<br> <li> Improves error handling and logging in verification<br> <li> Updates main <code>verifyAccountHash</code> to delegate based on tx type


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/225/files#diff-3917e7bd2a59e99c0a792c8725d95eb5bb43504675b3a48511617f02b20ec862">+72/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verifyGlobalTxReceipt.ts</strong><dd><code>Restrict and fix initial network/global tx receipt handling</code></dd></summary>
<hr>

src/shardeum/verifyGlobalTxReceipt.ts

<li>Checks <code>allowInitNetworkReceipts</code> before allowing InitNetwork tx<br> <li> Disables further initial network receipts after first use<br> <li> Fixes afterStateHash calculation and comparison for global tx


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/225/files#diff-9aed88fb73efd157c26b57ec9af61cad2ec0c9c0fde80bff01b82d1002645e89">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>