### PR TITLE
SHARD-2234 : Attack vector 1 - shard 2216

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,6 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
+  allowInitNetworkReceipts: boolean
 }
 
 let config: Config = {
@@ -285,6 +286,7 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
+  allowInitNetworkReceipts: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -1,6 +1,7 @@
 import { P2P } from '@shardeum-foundation/lib-types'
 import { ArchiverReceipt, Receipt } from '../dbstore/receipts'
 import { accountSpecificHash } from './calculateAccountHash'
+import { config } from '../Config'
 
 // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/shardeum/shardeumTypes.ts#L242
 export interface SetGlobalTxValue {
@@ -58,9 +59,10 @@ export const verifyGlobalTxAccountChange = (
     const signedReceipt = receipt.signedReceipt as P2P.GlobalAccountsTypes.GlobalTxReceipt
     const internalTx = signedReceipt.tx.value as SetGlobalTxValue
 
-    if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+    if (internalTx.internalTXType === InternalTXType.InitNetwork && config.allowInitNetworkReceipts) {
       // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/index.ts#L2334
       // no need to do anything, as it is network account creation
+      config.allowInitNetworkReceipts = false
       return true
     } else if (
       internalTx.internalTXType === InternalTXType.ApplyChangeConfig ||


### PR DESCRIPTION
Context : 

## 🔐 Vulnerability Summary

This document outlines multiple vulnerabilities in the handling and verification of **Global Transaction Receipts** in the Archiver component. Each vector enables potential state corruption or unauthorized account manipulation.

---

### 1. 🧨 InitNetwork Exploit (Global Tx Type: `InitNetwork`)

The function `verifyGlobalTxAccountChange()` fails to validate `afterStates` and their hashes for `InitNetwork` transactions.

#### ⚠️ How it works:
- The attacker modifies the receipt to set `globalModification = true`.
- They set `internalTx.type = InitNetwork`.
- The Archiver **skips all afterState validations** and blindly returns `true` for InitNetwork receipts.
- This allows **inflated balances or forged accounts** to bypass verification entirely.

🔗 **Code Reference**: [`verifyGlobalTxReceipt.ts#L61`](https://github.com/shardeum/archiver/blob/dev/src/shardeum/verifyGlobalTxReceipt.ts#L61)

---

### 2. 🧨 General Global Tx Exploit

For any global transaction type, **only `beforeState` hashes are verified**. The `afterStates` are trusted without recomputation, allowing attackers to forge balances or mutate state silently.

#### ⚠️ Issue:
- Instead of recalculating the hash of `afterStates`, the system **blindly compares** the `hash` field in `afterStates[i]` to the `afterStateHash` in the signed receipt.
- If the hash matches, even **mutated fields like balance or contract data** go undetected.

🔗 **Code Reference**: [`verifyGlobalTxReceipt.ts#L89-L130`](https://github.com/shardeum/archiver/blob/dev/src/shardeum/verifyGlobalTxReceipt.ts#L89-L130)

---

### 3. 🔁 Inconsistent Hash Recalculation Logic

#### 🔍 Problem in `calculateAccountHash.ts`:
The current `calculateAccountHash()` implementation **only uses a subset of fields** when hashing an account. For example, contract accounts only hash `codeHash` and `codeByte`.

```ts
else if (account.accountType === AccountType.ContractCode) {
  hash = crypto.hashObj({ key: account.codeHash, value: account.codeByte })
}
```

### **User description**
Enables the processing of initial network receipts by introducing a configuration flag.

This flag is enabled during the initial network setup to allow for network account creation, and then automatically disabled to prevent unintended usage after the initial setup.

https://linear.app/shm/issue/SHARD-2234/attack-vector-1-shard-2216


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces `allowInitNetworkReceipts` config flag for initial network setup

- Enables processing of initial network receipts only during setup

- Automatically disables receipt processing after first use

- Updates config interface and default values accordingly


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Config.ts</strong><dd><code>Add and initialize allowInitNetworkReceipts config flag</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Config.ts

<li>Added <code>allowInitNetworkReceipts</code> to <code>Config</code> interface and default config<br> <li> Set default value to <code>true</code> for initial network setup


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/226/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verifyGlobalTxReceipt.ts</strong><dd><code>Restrict InitNetwork receipt processing via config flag</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/verifyGlobalTxReceipt.ts

<li>Checks <code>allowInitNetworkReceipts</code> before processing InitNetwork receipts<br> <li> Disables <code>allowInitNetworkReceipts</code> after first InitNetwork receipt is <br>processed<br> <li> Imports <code>config</code> to access and update the flag


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/226/files#diff-9aed88fb73efd157c26b57ec9af61cad2ec0c9c0fde80bff01b82d1002645e89">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>