### PR TITLE
SHARD-2242 - Fix: empty previous cycle marker

### DIFF
--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -650,8 +650,10 @@ export function collectCycleData(
       let bestScore = 0
       let bestMarker = ''
       let prevMarker = ''
-      
-      // if the cache is empty, update the cache from the db
+
+      // If the cache is empty, update the cache from the db
+      // This change is to prevent the case where the archiver is not running when the cycle is created
+      // or the archiver is restarted and the cycle is not in the cache / fetching prev marker from empty cache
       if (cachedCycleRecords.length === 0) {
         updateCacheFromDB()
           .then(() => {
@@ -659,69 +661,76 @@ export function collectCycleData(
             if (cachedCycleRecords.length > 0 && cycle.counter - cachedCycleRecords[0].counter > 1) {
               Logger.mainLogger.debug(`updateCacheFromDB: No previous marker found for cycle ${cycle.counter}`)
             }
+            processCycleWithPrevMarker()
           })
           .catch((error) => {
             Logger.mainLogger.error(`updateCacheFromDB: Error updating cache from db: ${error}`)
           })
-      }
-
-      if (cachedCycleRecords.length > 0 && cycle.counter - cachedCycleRecords[0].counter === 1) {
-        prevMarker = cachedCycleRecords[0].marker
-        Logger.mainLogger.debug(`collectCycleData: Previous marker for scoring: ${prevMarker}`)
       } else {
-        Logger.mainLogger.debug(`collectCycleData: No previous marker found for cycle ${cycle.counter}`)
-        continue
-      }
-      // find the marker with largest sum of its top 3 cert scores
-      const markers = Object.entries(receivedCycleTracker[cycle.counter])
-        .filter(([key]) => key !== 'saved' && key !== 'received')
-        .map(([, value]) => value)
-
-      Logger.mainLogger.debug(`collectCycleData: Found ${markers.length} different markers for cycle ${cycle.counter}`)
-
-      for (const marker of markers) {
-        const scores = []
-        for (const signer of marker['certSigners']) {
-          const score = scoreCert(signer as string, prevMarker)
-          scores.push(score)
-          Logger.mainLogger.debug(`collectCycleData: Cert from ${signer} scored ${score}`)
-        }
-        // get sum of top 3 scores: sort scores in desc order, then slice off first 3 elements, and add them
-        const sum = scores
-          .sort((a, b) => b - a)
-          .slice(0, 3)
-          .reduce((sum, score) => (sum += score), 0)
-
-        Logger.mainLogger.debug(`collectCycleData: Marker ${marker['cycleInfo'].marker} scored ${sum}`)
-
-        if (sum > bestScore) {
-          bestScore = sum
-          bestMarker = marker['cycleInfo'].marker
-          Logger.mainLogger.debug(`collectCycleData: New best marker: ${bestMarker} with score ${bestScore}`)
-        }
+        processCycleWithPrevMarker()
       }
 
-      Logger.mainLogger.debug(
-        `collectCycleData: Processing cycle ${cycle.counter} with best marker ${bestMarker}, score: ${bestScore}`
-      )
-      processCycles([receivedCycleTracker[cycle.counter][bestMarker].cycleInfo])
-      receivedCycleTracker[cycle.counter]['saved'] = true
+      function processCycleWithPrevMarker() {
+        if (cachedCycleRecords.length > 0 && cycle.counter - cachedCycleRecords[0].counter === 1) {
+          prevMarker = cachedCycleRecords[0].marker
+          Logger.mainLogger.debug(`collectCycleData: Previous marker for scoring: ${prevMarker}`)
+        } else {
+          Logger.mainLogger.debug(`collectCycleData: No previous marker found for cycle ${cycle.counter}`)
+          return
+        }
+        // find the marker with largest sum of its top 3 cert scores
+        const markers = Object.entries(receivedCycleTracker[cycle.counter])
+          .filter(([key]) => key !== 'saved' && key !== 'received')
+          .map(([, value]) => value)
 
-      nestedCountersInstance.countEvent('collectCycleData', 'cycle_processed_successfully_' + cycle.mode, 1)
+        Logger.mainLogger.debug(
+          `collectCycleData: Found ${markers.length} different markers for cycle ${cycle.counter}`
+        )
 
-      ArchiverLogging.logDataSync({
-        sourceArchiver: senderInfo,
-        targetArchiver: config.ARCHIVER_IP,
-        cycle: cycle.counter,
-        dataType: 'CYCLE_RECORD',
-        dataHash: bestMarker,
-        status: 'COMPLETE',
-        operationId,
-        metrics: {
-          duration: Date.now() - startTime,
-          dataSize: StringUtils.safeStringify(receivedCycleTracker[cycle.counter][bestMarker].cycleInfo).length,
-        },
-      })
+        for (const marker of markers) {
+          const scores = []
+          for (const signer of marker['certSigners']) {
+            const score = scoreCert(signer as string, prevMarker)
+            scores.push(score)
+            Logger.mainLogger.debug(`collectCycleData: Cert from ${signer} scored ${score}`)
+          }
+          // get sum of top 3 scores: sort scores in desc order, then slice off first 3 elements, and add them
+          const sum = scores
+            .sort((a, b) => b - a)
+            .slice(0, 3)
+            .reduce((sum, score) => (sum += score), 0)
+
+          Logger.mainLogger.debug(`collectCycleData: Marker ${marker['cycleInfo'].marker} scored ${sum}`)
+
+          if (sum > bestScore) {
+            bestScore = sum
+            bestMarker = marker['cycleInfo'].marker
+            Logger.mainLogger.debug(`collectCycleData: New best marker: ${bestMarker} with score ${bestScore}`)
+          }
+        }
+
+        Logger.mainLogger.debug(
+          `collectCycleData: Processing cycle ${cycle.counter} with best marker ${bestMarker}, score: ${bestScore}`
+        )
+        processCycles([receivedCycleTracker[cycle.counter][bestMarker].cycleInfo])
+        receivedCycleTracker[cycle.counter]['saved'] = true
+
+        nestedCountersInstance.countEvent('collectCycleData', 'cycle_processed_successfully_' + cycle.mode, 1)
+
+        ArchiverLogging.logDataSync({
+          sourceArchiver: senderInfo,
+          targetArchiver: config.ARCHIVER_IP,
+          cycle: cycle.counter,
+          dataType: 'CYCLE_RECORD',
+          dataHash: bestMarker,
+          status: 'COMPLETE',
+          operationId,
+          metrics: {
+            duration: Date.now() - startTime,
+            dataSize: StringUtils.safeStringify(receivedCycleTracker[cycle.counter][bestMarker].cycleInfo).length,
+          },
+        })
+      }
     }
   }
 

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -41,7 +41,7 @@ import { AccountsCopy } from '../dbstore/accounts'
 import { getJson } from '../P2P'
 import { robustQuery } from '../Utils'
 import { Utils as StringUtils } from '@shardeum-foundation/lib-types'
-import { cachedCycleRecords } from '../cache/cycleRecordsCache'
+import { cachedCycleRecords, updateCacheFromDB } from '../cache/cycleRecordsCache'
 import { XOR } from '../utils/general'
 import { customFetch } from '../utils/customHttpFunctions'
 import { ArchiverLogging } from '../profiler/archiverLogging'
@@ -649,10 +649,29 @@ export function collectCycleData(
 
       let bestScore = 0
       let bestMarker = ''
+      let prevMarker = ''
+      
+      // if the cache is empty, update the cache from the db
+      if (cachedCycleRecords.length === 0) {
+        updateCacheFromDB()
+          .then(() => {
+            // Verify if cachedCycleRecords[0] is the previous cycle
+            if (cachedCycleRecords.length > 0 && cycle.counter - cachedCycleRecords[0].counter > 1) {
+              Logger.mainLogger.debug(`updateCacheFromDB: No previous marker found for cycle ${cycle.counter}`)
+            }
+          })
+          .catch((error) => {
+            Logger.mainLogger.error(`updateCacheFromDB: Error updating cache from db: ${error}`)
+          })
+      }
 
-      const prevMarker = cachedCycleRecords[0].marker
-      Logger.mainLogger.debug(`collectCycleData: Previous marker for scoring: ${prevMarker}`)
-
+      if (cachedCycleRecords.length > 0 && cycle.counter - cachedCycleRecords[0].counter === 1) {
+        prevMarker = cachedCycleRecords[0].marker
+        Logger.mainLogger.debug(`collectCycleData: Previous marker for scoring: ${prevMarker}`)
+      } else {
+        Logger.mainLogger.debug(`collectCycleData: No previous marker found for cycle ${cycle.counter}`)
+        continue
+      }
       // find the marker with largest sum of its top 3 cert scores
       const markers = Object.entries(receivedCycleTracker[cycle.counter])
         .filter(([key]) => key !== 'saved' && key !== 'received')

--- a/src/cache/cycleRecordsCache.ts
+++ b/src/cache/cycleRecordsCache.ts
@@ -8,7 +8,7 @@ export let cachedCycleRecords: P2P.CycleCreatorTypes.CycleData[] = []
 const signedCacheCycleRecords: Map<number, ArchiverCycleResponse> = new Map()
 let lastCacheUpdateFromDBRunning = false
 
-async function updateCacheFromDB(): Promise<void> {
+export async function updateCacheFromDB(): Promise<void> {
   if (lastCacheUpdateFromDBRunning) {
     return
   }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes handling of empty previous cycle marker in `collectCycleData`

- Adds cache update from DB when cache is empty

- Improves logging for missing previous marker scenarios

- Exports `updateCacheFromDB` for external use


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Data.ts</strong><dd><code>Fix previous cycle marker handling and cache update logic</code></dd></summary>
<hr>

src/Data/Data.ts

<li>Adds logic to update cache from DB if empty<br> <li> Handles cases where previous cycle marker is missing<br> <li> Improves logging for marker retrieval and errors<br> <li> Uses exported <code>updateCacheFromDB</code> function


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/231/files#diff-4966c3a37bd22c2d8ac54814304e5d4160c0cd9e1398b4e1dc7812ed8eba3178">+23/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cycleRecordsCache.ts</strong><dd><code>Export updateCacheFromDB for use in Data.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cache/cycleRecordsCache.ts

- Exports `updateCacheFromDB` function for external use


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/231/files#diff-7496ee32b99532d96f4d7da8aa025a38d43469d60b037dd6bf790fa3a91f5872">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>