### PR TITLE
SHARD-2234

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,7 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
-  allowInitNetworkReceipts: boolean
+
 }
 
 let config: Config = {
@@ -286,7 +286,6 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
-  allowInitNetworkReceipts: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,6 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
+  allowInitNetworkReceipts: boolean
 }
 
 let config: Config = {
@@ -285,6 +286,7 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
+  allowInitNetworkReceipts: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -629,7 +629,7 @@ export const verifyArchiverReceipt = async (
       }
     }
     if (config.verifyAccountData) {
-      const result = verifyAccountHash(receipt, failedReasons, nestedCounterMessages)
+      const result = await verifyAccountHash(receipt, failedReasons, nestedCounterMessages)
       if (!result) {
         failedReasons.push(`Invalid receipt: Account Verification failed ${txId}, ${receipt.cycle}, ${timestamp}`)
         nestedCounterMessages.push('Invalid_receipt_account_verification_failed')

--- a/src/dbstore/receipts.ts
+++ b/src/dbstore/receipts.ts
@@ -371,6 +371,46 @@ export async function queryReceiptsBetweenCycles(
   return receipts
 }
 
+export async function queryInitNetworkReceiptCountBetweenCycles(
+  startCycleNumber: number,
+  endCycleNumber: number
+): Promise<number> {
+  let count = 0
+  try {
+    const sql = `
+      SELECT * FROM receipts
+      WHERE cycle BETWEEN ? AND ?
+    `
+    const dbReceipts = (await db.all(receiptDatabase, sql, [startCycleNumber, endCycleNumber])) as DbReceipt[]
+
+    const filtered = dbReceipts.filter((receipt: DbReceipt) => {
+      deserializeDbReceipt(receipt)
+
+      // Inline type for safely accessing internalTXType
+      const tx = receipt.tx as {
+        originalTxData?: {
+          tx?: {
+            internalTXType?: number
+          }
+        }
+      }
+
+      return tx?.originalTxData?.tx?.internalTXType === 1
+    })
+
+    count = filtered.length
+  } catch (e) {
+    console.error('Error counting initNetwork receipts:', e)
+  }
+
+  if (config.VERBOSE) {
+    Logger.mainLogger.debug('InitNetwork receipt count between cycles:', count)
+  }
+
+  return count
+}
+
+
 function deserializeDbReceipt(receipt: DbReceipt): void {
   if (receipt.tx) receipt.tx = DeSerializeFromJsonString(receipt.tx)
   if (receipt.beforeStates) receipt.beforeStates = DeSerializeFromJsonString(receipt.beforeStates)

--- a/src/shardeum/calculateAccountHash.ts
+++ b/src/shardeum/calculateAccountHash.ts
@@ -3,6 +3,7 @@ import { ArchiverReceipt, SignedReceipt, Receipt } from '../dbstore/receipts'
 import { verifyPayload } from '../types/ajv/Helpers'
 import { AJVSchemaEnum } from '../types/enum/AJVSchemaEnum'
 import { verifyGlobalTxAccountChange } from './verifyGlobalTxReceipt'
+import * as ReceiptDB from '../dbstore/receipts'
 
 // account types in Shardeum
 export enum AccountType {
@@ -60,11 +61,11 @@ export const accountSpecificHash = (account: any): string => {
   return hash
 }
 
-export const verifyAccountHash = (
+export const verifyAccountHash = async(
   receipt: ArchiverReceipt | Receipt,
   failedReasons = [],
   nestedCounterMessages = []
-): boolean => {
+): Promise<boolean> => {
   try {
     let globalReceiptValidationErrors // This is used to store the validation errors of the globalTxReceipt
     try {
@@ -80,7 +81,7 @@ export const verifyAccountHash = (
       return false
     }
     if (!globalReceiptValidationErrors) {
-      const result = verifyGlobalTxAccountChange(receipt, failedReasons, nestedCounterMessages)
+      const result =  await verifyGlobalTxAccountChange(receipt, failedReasons, nestedCounterMessages)
       if (!result) return false
       return true
     }

--- a/src/shardeum/calculateAccountHash.ts
+++ b/src/shardeum/calculateAccountHash.ts
@@ -3,7 +3,6 @@ import { ArchiverReceipt, SignedReceipt, Receipt } from '../dbstore/receipts'
 import { verifyPayload } from '../types/ajv/Helpers'
 import { AJVSchemaEnum } from '../types/enum/AJVSchemaEnum'
 import { verifyGlobalTxAccountChange } from './verifyGlobalTxReceipt'
-import * as ReceiptDB from '../dbstore/receipts'
 
 // account types in Shardeum
 export enum AccountType {

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -1,7 +1,8 @@
 import { P2P } from '@shardeum-foundation/lib-types'
-import { ArchiverReceipt, Receipt } from '../dbstore/receipts'
+import { ArchiverReceipt, Receipt, queryInitNetworkReceiptCountBetweenCycles } from '../dbstore/receipts'
 import { accountSpecificHash } from './calculateAccountHash'
 import { config } from '../Config'
+import { ReceiptCheckpointBucket } from '../checkpoint/ReceiptData'
 
 // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/shardeum/shardeumTypes.ts#L242
 export interface SetGlobalTxValue {
@@ -50,19 +51,19 @@ export enum InternalTXType {
  * @param nestedCounterMessages - Array to collect counter messages for metrics
  * @returns boolean - True if verification passes, false otherwise
  */
-export const verifyGlobalTxAccountChange = (
+export const verifyGlobalTxAccountChange = async (
   receipt: ArchiverReceipt | Receipt,
   failedReasons = [],
   nestedCounterMessages = []
-): boolean => {
+): Promise<boolean> => {
   try {
     const signedReceipt = receipt.signedReceipt as P2P.GlobalAccountsTypes.GlobalTxReceipt
     const internalTx = signedReceipt.tx.value as SetGlobalTxValue
 
-    if (internalTx.internalTXType === InternalTXType.InitNetwork && config.allowInitNetworkReceipts) {
-      // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/index.ts#L2334
-      // no need to do anything, as it is network account creation
-      config.allowInitNetworkReceipts = false
+    if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+      let count = await queryInitNetworkReceiptCountBetweenCycles(1, 5)
+      if( count >= 1 )
+        return false
       return true
     } else if (
       internalTx.internalTXType === InternalTXType.ApplyChangeConfig ||

--- a/src/shardeum/verifyGlobalTxReceipt.ts
+++ b/src/shardeum/verifyGlobalTxReceipt.ts
@@ -1,6 +1,7 @@
 import { P2P } from '@shardeum-foundation/lib-types'
 import { ArchiverReceipt, Receipt } from '../dbstore/receipts'
 import { accountSpecificHash } from './calculateAccountHash'
+import { config } from '../Config'
 
 // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/shardeum/shardeumTypes.ts#L242
 export interface SetGlobalTxValue {
@@ -58,9 +59,10 @@ export const verifyGlobalTxAccountChange = (
     const signedReceipt = receipt.signedReceipt as P2P.GlobalAccountsTypes.GlobalTxReceipt
     const internalTx = signedReceipt.tx.value as SetGlobalTxValue
 
-    if (internalTx.internalTXType === InternalTXType.InitNetwork) {
+    if (internalTx.internalTXType === InternalTXType.InitNetwork && config.allowInitNetworkReceipts) {
       // Refer to https://github.com/shardeum/shardeum/blob/89db23e1d4ffb86b4353b8f37fb360ea3cd93c5b/src/index.ts#L2334
       // no need to do anything, as it is network account creation
+      config.allowInitNetworkReceipts = false
       return true
     } else if (
       internalTx.internalTXType === InternalTXType.ApplyChangeConfig ||


### PR DESCRIPTION
### **User description**
Removed flag and quering db instead to decide whether to accept initNetwork tx type receipt or not in archiver


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace config flag with DB query for InitNetwork receipt validation

- Add function to count InitNetwork receipts between cycles

- Refactor account hash and global tx verification to async

- Prevent duplicate InitNetwork receipts after initial acceptance


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Config.ts</strong><dd><code>Remove config flag for InitNetwork receipt handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Config.ts

<li>Removed unused config flag for InitNetwork receipt acceptance<br> <li> Minor formatting update


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/232/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Collector.ts</strong><dd><code>Make verifyAccountHash asynchronous in receipt verification</code></dd></summary>
<hr>

src/Data/Collector.ts

- Refactored verifyAccountHash call to be async/await


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/232/files#diff-186c711dbe48d8ffd4c6488e2d29090dae64abd946a5cf185a549af2c556a72e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>receipts.ts</strong><dd><code>Add function to count InitNetwork receipts in DB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/dbstore/receipts.ts

<li>Added queryInitNetworkReceiptCountBetweenCycles to count InitNetwork <br>receipts<br> <li> Uses SQL and filtering to identify InitNetwork receipts<br> <li> Logs count if verbose mode is enabled


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/232/files#diff-e644b6b6f429a07840b014023c9b7412f31a9821c05283431844d275fa4b9a81">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>calculateAccountHash.ts</strong><dd><code>Refactor account hash verification to async/await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardeum/calculateAccountHash.ts

<li>Refactored verifyAccountHash to be async<br> <li> Updated internal call to verifyGlobalTxAccountChange to be awaited<br> <li> Imported ReceiptDB for potential future use


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/232/files#diff-3917e7bd2a59e99c0a792c8725d95eb5bb43504675b3a48511617f02b20ec862">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verifyGlobalTxReceipt.ts</strong><dd><code>Async global tx verification and DB-based InitNetwork check</code></dd></summary>
<hr>

src/shardeum/verifyGlobalTxReceipt.ts

<li>Refactored verifyGlobalTxAccountChange to be async<br> <li> For InitNetwork, queries DB to prevent duplicate acceptance<br> <li> Imports new DB query and config


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/232/files#diff-9aed88fb73efd157c26b57ec9af61cad2ec0c9c0fde80bff01b82d1002645e89">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>