### PR TITLE
feat: enhance secure accounts loading with absolute path

### DIFF
--- a/src/services/transactionVerification.ts
+++ b/src/services/transactionVerification.ts
@@ -5,7 +5,7 @@ import * as P2P from '../P2P'
 import * as NodeList from '../NodeList'
 import { robustQuery, verifyMultiSigs } from '../Utils'
 import { DevSecurityLevel } from '../types/security'
-import { join } from 'path'
+import { join, isAbsolute } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import { Transaction, TransactionFactory, TransactionType, TypedTransaction } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
@@ -23,23 +23,34 @@ interface SecureAccountData {
 let secureAccountsFilePath = join(__dirname, '..', '..', 'static', 'genesis-secure-accounts.json')
 let secureAccountDataMap: Map<string, SecureAccountData> | null = null
 
+// Allow overriding genesis secure accounts file via env var, supporting absolute or relative paths
 if (process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS) {
-  const GSAFilePath = process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS
-  GSAFilePath.trim()
-
+  const gsaEnvPath = process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS.trim()
   try {
-    if (existsSync(join(__dirname, '..', '..', 'static', GSAFilePath))) {
-      secureAccountsFilePath = join(__dirname, '..', '..', 'static', GSAFilePath)
-      console.log('secureAccounts: genesis secure path set to:', GSAFilePath)
+    if (isAbsolute(gsaEnvPath)) {
+      // Absolute path provided
+      if (existsSync(gsaEnvPath)) {
+        secureAccountsFilePath = gsaEnvPath
+        console.log('secureAccounts: genesis secure path set to absolute path:', gsaEnvPath)
+      } else {
+        throw new Error(`secureAccounts: absolute path to genesis secure accounts file is incorrect: ${gsaEnvPath}`)
+      }
     } else {
-      throw new Error('secureAccounts: path to the following genesis secure accounts file is incorrect:' + GSAFilePath)
+      // Relative path provided, resolve under static directory
+      const relPath = join(__dirname, '..', '..', 'static', gsaEnvPath)
+      if (existsSync(relPath)) {
+        secureAccountsFilePath = relPath
+        console.log('secureAccounts: genesis secure path set to relative path:', gsaEnvPath)
+      } else {
+        throw new Error(`secureAccounts: path to the following genesis secure accounts file is incorrect: ${relPath}`)
+      }
     }
   } catch (e) {
     throw new Error('secureAccounts: error setting genesis secure accounts file path: ' + e)
   }
 }
 
-const getSecureAccounts = (): Map<string, SecureAccountData> => {
+export const getSecureAccounts = (): Map<string, SecureAccountData> => {
   if (!secureAccountDataMap) {
     try {
       const data = readFileSync(secureAccountsFilePath, 'utf8')

--- a/test/unit/src/services/transactionVerification.test.ts
+++ b/test/unit/src/services/transactionVerification.test.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+describe('Transaction Verification Service secureAccounts override', () => {
+  const originalEnv = process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS
+  const modulePath = '../../../../src/services/transactionVerification'
+
+  afterEach(async () => {
+    if (originalEnv === undefined) {
+      delete process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS
+    } else {
+      process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS = originalEnv
+    }
+    jest.resetModules()
+  })
+
+  it('should load secure accounts from absolute path', async () => {
+    jest.resetModules()
+    const tempFilePath = path.join(os.tmpdir(), `test-secure-accounts-abs-${Date.now()}.json`)
+    const testData = [
+      {
+        Name: 'TestAbs',
+        SourceFundsAddress: '0xabc',
+        RecipientFundsAddress: '0xdef',
+        SecureAccountAddress: '0x123',
+      },
+    ]
+    await fs.writeFile(tempFilePath, JSON.stringify(testData), 'utf8')
+    process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS = tempFilePath
+    const { getSecureAccounts } = require(modulePath)
+    const map = getSecureAccounts()
+    const account = map.get('TestAbs')
+    expect(account).toBeDefined()
+    expect(account.SourceFundsAddress).toBe('0xabc')
+    await fs.unlink(tempFilePath)
+  })
+
+  it('should load secure accounts from relative path', async () => {
+    jest.resetModules()
+    // Mock fs.existsSync and fs.readFileSync for relative path
+    const fsActual = require('fs')
+    const staticDir = path.join(process.cwd(), 'static')
+    const testFilename = `test-secure-accounts-rel-${Date.now()}.json`
+    const filePath = path.join(staticDir, testFilename)
+    const testData = [
+      {
+        Name: 'TestRel',
+        SourceFundsAddress: '0xabc',
+        RecipientFundsAddress: '0xdef',
+        SecureAccountAddress: '0x456',
+      },
+    ]
+    const existsSyncSpy = jest.spyOn(fsActual, 'existsSync').mockImplementation((p) => p === filePath)
+    const readFileSyncSpy = jest.spyOn(fsActual, 'readFileSync').mockImplementation(() => JSON.stringify(testData))
+    process.env.LOAD_JSON_GENESIS_SECURE_ACCOUNTS = testFilename
+    const { getSecureAccounts } = require(modulePath)
+    const map = getSecureAccounts()
+    const account = map.get('TestRel')
+    expect(account).toBeDefined()
+    expect(account.SecureAccountAddress).toBe('0x456')
+    // restore fs spies
+    existsSyncSpy.mockRestore()
+    readFileSyncSpy.mockRestore()
+  })
+}) 


### PR DESCRIPTION
adds support for absolute path for the `LOAD_JSON_GENESIS_SECURE_ACCOUNTS` env variable

fixes https://linear.app/shm/issue/SHARD-2260/archiver-should-use-absolute-path-for-load-json-genesis-secure#comment-38ac08a6