### PR TITLE
SHARD-2420 : Fixes archiver issue where successful receipts get overwritten by newer failure receipts

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,6 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
+  enableStatusLogic: boolean
 }
 
 let config: Config = {
@@ -285,6 +286,7 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
+  enableStatusLogic: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -134,7 +134,7 @@ export interface Config {
   nerfNonFoundationCertScores: boolean
   formingNetworkCycleThreshold: number // CODE REVIEW WARNING: never allow this to be set more than 30.  we have some trusted execution until this cycle is reached (specifically allowing global tx receipts) - will be refactored to be avoided
   maxResponseSize: number
-  enableStatusLogic: boolean
+  enableDuplicateReceiptsCheck: boolean // To enable duplicate receipts check in storeReceiptData and not allow overwriting of success with failure
 }
 
 let config: Config = {
@@ -286,7 +286,7 @@ let config: Config = {
   nerfNonFoundationCertScores: true,
   formingNetworkCycleThreshold: 30,
   maxResponseSize: 15 * 1024 * 1024, // 15MB
-  enableStatusLogic: true,
+  enableDuplicateReceiptsCheck: true,
 }
 // Override default config params from config file, env vars, and cli args
 export async function overrideDefaultConfig(file: string): Promise<void> {

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -776,7 +776,7 @@ export const storeReceiptData = async (
         continue
       }
 
-      if (config.enableStatusLogic && !receipt.globalModification) {
+      if (config.enableDuplicateReceiptsCheck && !receipt.globalModification) {
         // only consider this for EVM txns and Non Global Internal Txns
         const result = await checkIfValidOverwrite(receipt, txId)
         if (!result) {

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -680,6 +680,10 @@ export async function checkIfValidOverwrite(receipt: any, txId: string): Promise
       )
     }
     if (config.VERBOSE) console.log('Duplicate receipts were found for the txId', txId)
+    if (config.VERBOSE)
+      console.log(
+        `Existing Receipt : ${StringUtils.safeStringify(existingReceipt)} Incoming Receipt : ${StringUtils.safeStringify(receipt)}`
+      )
     nestedCountersInstance.countEvent('duplicate-receipts', `txId : ${txId}`)
 
     const existingShardeumReceipt = existingReceipt.appReceiptData.data as ShardeumReceipt

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -654,32 +654,47 @@ export const verifyArchiverReceipt = async (
   }
 }
 
-/*
-    incoming :  in dB
-      0 -> 1 : dont replace and reject incoming receipt
-      1 -> 0 : replace  // do as it is
-      1 -> 1 : let it be // impossible
-      0 -> 0 : replace // do as it is
-
-    */
+/**
+ * Determines whether a new receipt should be allowed to overwrite an existing receipt in the database.
+ *
+ * Receipt status overwrite logic:
+ * Incoming Status : Existing Status
+ * - 0 -> 1: Don't replace (reject incoming receipt with failure if existing has success)
+ * - 1 -> 0: Replace (allow overwriting failure with success)
+ * - 1 -> 1: Won't happen (impossible case, nonce will change)
+ * - 0 -> 0: Replace (allow overwriting failure with failure)
+ *
+ * @param {any} receipt - The incoming receipt that may overwrite an existing one
+ * @param {string} txId - The transaction ID to check for existing receipts
+ * @returns {Promise<boolean>} True if overwrite is allowed, false if rejected
+ */
 export async function checkIfValidOverwrite(receipt: any, txId: string): Promise<boolean> {
-  const existingReceipt = await queryReceiptByReceiptId(txId)
-  if (!existingReceipt) return true // receipt came for the first time, let it insert
+  try {
+    const existingReceipt = await queryReceiptByReceiptId(txId)
+    if (!existingReceipt) return true // receipt came for the first time, let it insert
 
-  // we found a duplicate receipt
-  if (config.dataLogWrite && ReceiptOverwriteLogWriter) {
-    ReceiptOverwriteLogWriter.writeToLog(
-      `Existing Receipt : ${StringUtils.safeStringify(existingReceipt)} Incoming Receipt : ${StringUtils.safeStringify(receipt)}`
-    )
+    // we found a duplicate receipt
+    if (config.dataLogWrite && ReceiptOverwriteLogWriter) {
+      ReceiptOverwriteLogWriter.writeToLog(
+        `Existing Receipt : ${StringUtils.safeStringify(existingReceipt)} Incoming Receipt : ${StringUtils.safeStringify(receipt)}`
+      )
+    }
+    if (config.VERBOSE) console.log('Duplicate receipts were found for the txId', txId)
+    nestedCountersInstance.countEvent('duplicate-receipts', `txId : ${txId}`)
+
+    const existingShardeumReceipt = existingReceipt.appReceiptData.data as ShardeumReceipt
+    const existingStatus = existingShardeumReceipt.readableReceipt.status
+    if (existingStatus === 1) {
+      return false // you cannot override a successful receipt (status 1) with any new receipt
+    } else return true // if the existingStatus is 0 (failure), let the new receipt ( be it with status 0 or 1) override the old failure receipt
+  } catch (error) {
+    // Log the error with context about what operation was attempted
+    Logger.mainLogger.error(`Error in checkIfValidOverwrite for txId ${txId}: ${error.message}`, error)
+    if (nestedCountersInstance) nestedCountersInstance.countEvent('receipt', 'checkIfValidOverwrite_error')
+
+    // Default to rejecting the overwrite in case of error to be safe
+    return false
   }
-  if (config.VERBOSE) console.log('Duplicate receipts were found for the txId', txId)
-  nestedCountersInstance.countEvent('duplicate-receipts', `txId : ${txId}`)
-
-  const existingShardeumReceipt = existingReceipt.appReceiptData.data as ShardeumReceipt
-  const existingStatus = existingShardeumReceipt.readableReceipt.status
-  if (existingStatus === 1) {
-    return false // you cannot override the old receipt and datalog write and nestedCounter
-  } else return true // if the existingStatus is 0 and the incomingStatus is 0/1, let the new receipt override the old failure receipt
 }
 
 /**
@@ -761,8 +776,8 @@ export const storeReceiptData = async (
         continue
       }
 
-      if (!receipt.globalModification) {
-        // only consider this EVM txns and Non Global Internal Txns
+      if (config.enableStatusLogic && !receipt.globalModification) {
+        // only consider this for EVM txns and Non Global Internal Txns
         const result = await checkIfValidOverwrite(receipt, txId)
         if (!result) {
           continue // if the incoming receipt has a status of 0, do not allow it to overwrite a receipt of status 1

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -17,11 +17,16 @@ import * as Utils from '../Utils'
 import { DataType, GossipData, sendDataToAdjacentArchivers, TxData } from './GossipData'
 import { postJson } from '../P2P'
 import { globalAccountsMap, setGlobalNetworkAccount } from '../GlobalAccount'
-import { CycleLogWriter, ReceiptLogWriter, OriginalTxDataLogWriter } from '../Data/DataLogWriter'
+import {
+  CycleLogWriter,
+  ReceiptLogWriter,
+  OriginalTxDataLogWriter,
+  ReceiptOverwriteLogWriter,
+} from '../Data/DataLogWriter'
 import * as OriginalTxDB from '../dbstore/originalTxsData'
 import ShardFunction from '../ShardFunctions'
 import { accountSpecificHash, verifyAccountHash } from '../shardeum/calculateAccountHash'
-import { verifyAppReceiptData } from '../shardeum/verifyAppReceiptData'
+import { ShardeumReceipt, verifyAppReceiptData } from '../shardeum/verifyAppReceiptData'
 import { Cycle as DbCycle } from '../dbstore/types'
 import { Utils as StringUtils } from '@shardeum-foundation/lib-types'
 import { verifyPayload } from '../types/ajv/Helpers'
@@ -29,6 +34,7 @@ import { AJVSchemaEnum } from '../types/enum/AJVSchemaEnum'
 import { verifyTransaction } from '../services/transactionVerification'
 import { CycleShardData } from '@shardeum-foundation/lib-types/build/src/state-manager/shardFunctionTypes'
 import { generateTxId } from '../Utils'
+import { queryReceiptByReceiptId } from '../dbstore/receipts'
 
 export let storingAccountData = false
 const processedReceiptsMap: Map<string, number> = new Map()
@@ -648,6 +654,34 @@ export const verifyArchiverReceipt = async (
   }
 }
 
+/*
+    incoming :  in dB
+      0 -> 1 : dont replace and reject incoming receipt
+      1 -> 0 : replace  // do as it is
+      1 -> 1 : let it be // impossible
+      0 -> 0 : replace // do as it is
+
+    */
+export async function checkIfValidOverwrite(receipt: any, txId: string): Promise<boolean> {
+  const existingReceipt = await queryReceiptByReceiptId(txId)
+  if (!existingReceipt) return true // receipt came for the first time, let it insert
+
+  // we found a duplicate receipt
+  if (config.dataLogWrite && ReceiptOverwriteLogWriter) {
+    ReceiptOverwriteLogWriter.writeToLog(
+      `Existing Receipt : ${StringUtils.safeStringify(existingReceipt)} Incoming Receipt : ${StringUtils.safeStringify(receipt)}`
+    )
+  }
+  if (config.VERBOSE) console.log('Duplicate receipts were found for the txId', txId)
+  nestedCountersInstance.countEvent('duplicate-receipts', `txId : ${txId}`)
+
+  const existingShardeumReceipt = existingReceipt.appReceiptData.data as ShardeumReceipt
+  const existingStatus = existingShardeumReceipt.readableReceipt.status
+  if (existingStatus === 1) {
+    return false // you cannot override the old receipt and datalog write and nestedCounter
+  } else return true // if the existingStatus is 0 and the incomingStatus is 0/1, let the new receipt override the old failure receipt
+}
+
 /**
  * Stores receipt data in the database.
  *
@@ -725,6 +759,14 @@ export const storeReceiptData = async (
         if (nestedCountersInstance) nestedCountersInstance.countEvent('receipt', 'Invalid_receipt_validation_failed')
         if (profilerInstance) profilerInstance.profileSectionEnd('Validate_receipt')
         continue
+      }
+
+      if (!receipt.globalModification) {
+        // only consider this EVM txns and Non Global Internal Txns
+        const result = await checkIfValidOverwrite(receipt, txId)
+        if (!result) {
+          continue // if the incoming receipt has a status of 0, do not allow it to overwrite a receipt of status 1
+        }
       }
 
       if (verifyData) {
@@ -850,17 +892,13 @@ export const storeReceiptData = async (
       // )
       //   continue
 
-      
       if (globalModification) {
-        let globalReceiptValidationErrors 
+        let globalReceiptValidationErrors
         try {
-          
           globalReceiptValidationErrors = verifyPayload(AJVSchemaEnum.GlobalTxReceipt, receipt?.signedReceipt)
-          
+
           if (!globalReceiptValidationErrors) {
-
             for (const account of afterStates) {
-
               const accObj: Account.AccountsCopy = {
                 accountId: config.globalNetworkAccount, // for global tx type receipts fixing accountID to 1000000000000000000000000000000000000000000000000000000000000001 for now
                 data: account.data,
@@ -873,7 +911,7 @@ export const storeReceiptData = async (
                 Logger.mainLogger.error('Mismatched account timestamp', txId, account.accountId)
               if (account.hash !== account.data['hash'])
                 Logger.mainLogger.error('Mismatched account hash', txId, account.accountId)
-      
+
               const accountExist = await Account.queryAccountByAccountId(account.accountId)
               if (accountExist) {
                 if (accObj.timestamp > accountExist.timestamp) await Account.updateAccount(accObj)
@@ -881,7 +919,7 @@ export const storeReceiptData = async (
                 // await Account.insertAccount(accObj)
                 combineAccounts.push(accObj)
               }
-      
+
               //check global network account updates
               if (accObj.accountId === config.globalNetworkAccount) {
                 setGlobalNetworkAccount(accObj)
@@ -893,8 +931,7 @@ export const storeReceiptData = async (
                 })
               }
             }
-            
-          } 
+          }
         } catch (error) {
           globalReceiptValidationErrors = true
           if (nestedCountersInstance)
@@ -908,16 +945,16 @@ export const storeReceiptData = async (
         }
       } else {
         try {
-          const signedReceipt = receipt.signedReceipt as Receipt.SignedReceipt;
-          const { accountIDs } = signedReceipt.proposal;
-      
+          const signedReceipt = receipt.signedReceipt as Receipt.SignedReceipt
+          const { accountIDs } = signedReceipt.proposal
+
           for (const accountId of accountIDs) {
-            const account = receipt.afterStates.find((acc) => acc.accountId === accountId);
+            const account = receipt.afterStates.find((acc) => acc.accountId === accountId)
             if (!account) {
-              Logger.mainLogger.error('Account not found in afterStates', txId, accountId);
-              continue;
+              Logger.mainLogger.error('Account not found in afterStates', txId, accountId)
+              continue
             }
-      
+
             const accObj: Account.AccountsCopy = {
               accountId: account.accountId,
               data: account.data,
@@ -925,20 +962,20 @@ export const storeReceiptData = async (
               hash: account.hash,
               cycleNumber: cycle,
               isGlobal: account.isGlobal || false,
-            };
-      
+            }
+
             if (account.timestamp !== account.data['timestamp']) {
-              Logger.mainLogger.error('Mismatched account timestamp', txId, account.accountId);
+              Logger.mainLogger.error('Mismatched account timestamp', txId, account.accountId)
             }
             if (account.hash !== account.data['hash']) {
-              Logger.mainLogger.error('Mismatched account hash', txId, account.accountId);
+              Logger.mainLogger.error('Mismatched account hash', txId, account.accountId)
             }
-      
-            const accountExist = await Account.queryAccountByAccountId(account.accountId);
+
+            const accountExist = await Account.queryAccountByAccountId(account.accountId)
             if (accountExist) {
-              if (accObj.timestamp > accountExist.timestamp) await Account.updateAccount(accObj);
+              if (accObj.timestamp > accountExist.timestamp) await Account.updateAccount(accObj)
             } else {
-              combineAccounts.push(accObj);
+              combineAccounts.push(accObj)
             }
           }
         } catch (error) {
@@ -946,14 +983,14 @@ export const storeReceiptData = async (
             nestedCountersInstance.countEvent(
               'receipt',
               `Failed to process non-global receipt txId: ${txId}, cycle: ${cycle}, timestamp: ${timestamp}, error: ${error}`
-            );
+            )
           }
           Logger.mainLogger.error(
             `Failed to process non-global receipt txId: ${txId}, cycle: ${cycle}, timestamp: ${timestamp}, error: ${error}`
-          );
+          )
         }
       }
-      
+
       // if (receipt) {
       //   const accObj: Account.AccountsCopy = {
       //     accountId: receipt.accountId,

--- a/src/Data/DataLogWriter.ts
+++ b/src/Data/DataLogWriter.ts
@@ -216,10 +216,17 @@ class DataLogWriter {
 export let CycleLogWriter: DataLogWriter
 export let ReceiptLogWriter: DataLogWriter
 export let OriginalTxDataLogWriter: DataLogWriter
+export let ReceiptOverwriteLogWriter: DataLogWriter
 
 export async function initDataLogWriter(): Promise<void> {
   CycleLogWriter = new DataLogWriter('cycle', 1, LOG_WRITER_CONFIG.maxCycleEntries)
   ReceiptLogWriter = new DataLogWriter('receipt', 1, LOG_WRITER_CONFIG.maxReceiptEntries)
   OriginalTxDataLogWriter = new DataLogWriter('originalTx', 1, LOG_WRITER_CONFIG.maxOriginalTxEntries)
-  await Promise.all([CycleLogWriter.init(), ReceiptLogWriter.init(), OriginalTxDataLogWriter.init()])
+  ReceiptOverwriteLogWriter = new DataLogWriter('receiptOverwrite', 1, LOG_WRITER_CONFIG.maxOriginalTxEntries)
+  await Promise.all([
+    CycleLogWriter.init(),
+    ReceiptLogWriter.init(),
+    OriginalTxDataLogWriter.init(),
+    ReceiptOverwriteLogWriter.init(),
+  ])
 }

--- a/src/Data/DataLogWriter.ts
+++ b/src/Data/DataLogWriter.ts
@@ -137,10 +137,20 @@ class DataLogWriter {
     console.log(`> DataLogWriter: Rotated log file: ${this.dataName}-log${this.logCounter}.txt`)
   }
 
+  /**
+   * Asynchronously writes data to the log.
+   *
+   * @param {string} data - The data string to be written to the log.
+   * @returns {Promise<void>} A promise that resolves when the data is successfully queued for writing.
+   */
   async writeToLog(data: string): Promise<void> {
-    this.writeQueue.push(data)
-    if (!this.isWriting) await this.insertDataLog()
-    // else console.log('❌❌❌ Already writing...')
+    try {
+      this.writeQueue.push(data)
+      if (!this.isWriting) await this.insertDataLog()
+      // else console.log('❌❌❌ Already writing...')
+    } catch (error) {
+      console.error('Error in writeToLog:', error)
+    }
   }
 
   async insertDataLog(): Promise<void> {
@@ -218,6 +228,15 @@ export let ReceiptLogWriter: DataLogWriter
 export let OriginalTxDataLogWriter: DataLogWriter
 export let ReceiptOverwriteLogWriter: DataLogWriter
 
+/**
+ * Initializes the data log writers for various log types.
+ *
+ * This function sets up the log writers for cycle, receipt, original transaction data,
+ * and receipt overwrite logs. It creates instances of `DataLogWriter` for each log type
+ * and initializes them with their respective configurations.
+ *
+ * @returns {Promise<void>} A promise that resolves when all log writers are initialized.
+ */
 export async function initDataLogWriter(): Promise<void> {
   CycleLogWriter = new DataLogWriter('cycle', 1, LOG_WRITER_CONFIG.maxCycleEntries)
   ReceiptLogWriter = new DataLogWriter('receipt', 1, LOG_WRITER_CONFIG.maxReceiptEntries)


### PR DESCRIPTION
### **User description**
Problem:
The StoreReceiptData logic on the archiver side is overwriting older receipts stored in the database. This means that if a transaction was previously executed successfully and its receipt was saved, a later failure receipt can replace the original. This may happen due to influencer mode or dirty transaction state from the validator. Although the failure receipt has consensus, its contents may incorrectly indicate that funds were not transferred when they actually were.

Solution:
By checking the transaction status in the receipt, we can determine whether a receipt should be overwritten. This will prevent successful transaction receipts from being replaced by failure receipts.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Prevents overwriting successful receipts with failure receipts.

- Adds config flag `enableDuplicateReceiptsCheck` for overwrite protection.

- Introduces logging for duplicate receipt overwrite attempts.

- Refactors and improves error handling in receipt storage logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Config.ts</strong><dd><code>Add config flag for duplicate receipt overwrite protection</code></dd></summary>
<hr>

src/Config.ts

<li>Adds <code>enableDuplicateReceiptsCheck</code> config flag to control duplicate <br>receipt logic.<br> <li> Sets default value for the new config flag.


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/242/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Collector.ts</strong><dd><code>Add receipt overwrite protection and duplicate logging</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Data/Collector.ts

<li>Implements <code>checkIfValidOverwrite</code> to prevent overwriting success <br>receipts with failures.<br> <li> Integrates overwrite check into <code>storeReceiptData</code> using the new config <br>flag.<br> <li> Adds logging for duplicate receipt scenarios.<br> <li> Refactors receipt storage logic for clarity and error handling.


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/242/files#diff-186c711dbe48d8ffd4c6488e2d29090dae64abd946a5cf185a549af2c556a72e">+82/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataLogWriter.ts</strong><dd><code>Add log writer for receipt overwrite attempts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Data/DataLogWriter.ts

<li>Adds <code>ReceiptOverwriteLogWriter</code> for logging overwrite attempts.<br> <li> Initializes new log writer in <code>initDataLogWriter</code>.


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/242/files#diff-ef69489a30801b1daea305d716a10ba13964ef63c7cd3d6179ef6f38e09eb107">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>