### PR TITLE
SHARD-2447: remove restriction for activeArchiver length smaller than 4

### DIFF
--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -1002,6 +1002,10 @@ export async function createDataTransferConnection(newSenderInfo: NodeList.Conse
   return response
 }
 
+function shouldSubscribeToMoreConsensors(): boolean {
+  return config.subscribeToMoreConsensors && currentConsensusRadius > 5
+}
+
 export async function createNodesGroupByConsensusRadius(): Promise<void> {
   const consensusRadius = await getConsensusRadius()
   if (consensusRadius === 0) {
@@ -1013,7 +1017,7 @@ export async function createNodesGroupByConsensusRadius(): Promise<void> {
   if (config.VERBOSE) Logger.mainLogger.debug('activeList', activeList.length, activeList)
   let totalNumberOfNodesToSubscribe = Math.ceil(activeList.length / consensusRadius)
   // Only if there are less than 4 activeArchivers and if the consensusRadius is greater than 5
-  if (config.subscribeToMoreConsensors && currentConsensusRadius > 5) {
+  if (shouldSubscribeToMoreConsensors()) {
     totalNumberOfNodesToSubscribe += totalNumberOfNodesToSubscribe * config.extraConsensorsToSubscribe
   }
   Logger.mainLogger.debug('totalNumberOfNodesToSubscribe', totalNumberOfNodesToSubscribe)
@@ -1047,7 +1051,7 @@ export async function subscribeNodeFromThisSubset(nodeList: NodeList.ConsensusNo
   }
   let numberOfNodesToSubsribe = 1
   // Only if there are less than 4 activeArchivers and if the consensusRadius is greater than 5
-  if (config.subscribeToMoreConsensors && currentConsensusRadius > 5) {
+  if (shouldSubscribeToMoreConsensors()) {
     numberOfNodesToSubsribe += config.extraConsensorsToSubscribe
   }
   if (subscribedNodesFromThisSubset.length > numberOfNodesToSubsribe) {

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -1013,7 +1013,7 @@ export async function createNodesGroupByConsensusRadius(): Promise<void> {
   if (config.VERBOSE) Logger.mainLogger.debug('activeList', activeList.length, activeList)
   let totalNumberOfNodesToSubscribe = Math.ceil(activeList.length / consensusRadius)
   // Only if there are less than 4 activeArchivers and if the consensusRadius is greater than 5
-  if (config.subscribeToMoreConsensors && State.activeArchivers.length < 4 && currentConsensusRadius > 5) {
+  if (config.subscribeToMoreConsensors && currentConsensusRadius > 5) {
     totalNumberOfNodesToSubscribe += totalNumberOfNodesToSubscribe * config.extraConsensorsToSubscribe
   }
   Logger.mainLogger.debug('totalNumberOfNodesToSubscribe', totalNumberOfNodesToSubscribe)
@@ -1047,7 +1047,7 @@ export async function subscribeNodeFromThisSubset(nodeList: NodeList.ConsensusNo
   }
   let numberOfNodesToSubsribe = 1
   // Only if there are less than 4 activeArchivers and if the consensusRadius is greater than 5
-  if (config.subscribeToMoreConsensors && State.activeArchivers.length < 4 && currentConsensusRadius > 5) {
+  if (config.subscribeToMoreConsensors && currentConsensusRadius > 5) {
     numberOfNodesToSubsribe += config.extraConsensorsToSubscribe
   }
   if (subscribedNodesFromThisSubset.length > numberOfNodesToSubsribe) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed restriction on `activeArchivers` length for extra consensuser subscription

- Updated logic in node group creation and subscription functions

- Ensured extra consensuser logic applies regardless of `activeArchivers` count


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Data.ts</strong><dd><code>Remove activeArchivers length check for consensuser subscription</code></dd></summary>
<hr>

src/Data/Data.ts

<li>Removed check for <code>State.activeArchivers.length < 4</code> in two conditional <br>statements<br> <li> Now allows extra consensuser subscription when <br><code>subscribeToMoreConsensors</code> is true and <code>currentConsensusRadius > 5</code><br> <li> Affects both node group creation and node subset subscription logic


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/256/files#diff-4966c3a37bd22c2d8ac54814304e5d4160c0cd9e1398b4e1dc7812ed8eba3178">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>