### PR TITLE
SHARD-2450: Improve archiver sync + Remove true flag from storeReceiptData for receipts coming from archiver

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -52,6 +52,7 @@ export interface Config {
     maxCyclesToSync: number
     syncOnStartup: boolean
     statusArraySize: number
+    syncCycleBuffer: number
   }
   dataLogWrite: boolean
   dataLogWriter: {
@@ -213,6 +214,7 @@ let config: Config = {
     maxCyclesToSync: 100, // Maximum number of cycles to sync in one go
     statusArraySize: 5000, // Number of statuses to keep in the status array
     syncOnStartup: false, // Sync missing checkpoints on startup
+    syncCycleBuffer: 50, // Number of cycles to substract from the last updated cycle
   },
   cycleRecordsCache: {
     enabled: false,

--- a/src/Data/Collector.ts
+++ b/src/Data/Collector.ts
@@ -1561,7 +1561,7 @@ export const collectMissingReceipts = async (senders: string[], txId: string, tx
       for (const receipt of receipts) {
         const { receiptId, timestamp } = receipt
         if (txId === receiptId && txTimestamp === timestamp) {
-          storeReceiptData([receipt], senderArchiver.ip + ':' + senderArchiver.port, true)
+          storeReceiptData([receipt], senderArchiver.ip + ':' + senderArchiver.port, false)
           foundTxData = true
         }
       }

--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -1768,9 +1768,24 @@ export async function syncCyclesBetweenCycles(lastStoredCycle = 0, cycleToSyncTo
   return true
 }
 
+import { getLastUpdatedCycle, updateLastUpdatedCycle } from '../utils/cycleTracker'
+
 export async function syncReceipts(): Promise<void> {
   const MAX_RETRIES = 3
   let retryCount = 0
+
+  // Get the last updated cycle from tracker file
+  const lastUpdatedCycle = getLastUpdatedCycle()
+  Logger.mainLogger.debug(`[syncReceipts] Last updated cycle from tracker: ${lastUpdatedCycle}`)
+  
+  // If we have a valid last updated cycle, use it as the starting point
+  let startCycle = 0
+  if (lastUpdatedCycle > 0) {
+    Logger.mainLogger.info(`[syncReceipts] Starting receipt sync from last updated cycle: ${lastUpdatedCycle}`)
+    startCycle = Math.max(lastUpdatedCycle - config.checkpoint.syncCycleBuffer, 0)
+    await syncReceiptsByCycle(startCycle)
+    return
+  }
 
   let response: ArchiverTotalDataResponse = await getTotalDataFromArchivers()
   if (!response || response.totalReceipts < 0) {
@@ -1894,6 +1909,15 @@ class ArchiverSelector {
 }
 
 export async function syncReceiptsByCycle(lastStoredReceiptCycle = 0, cycleToSyncTo = 0): Promise<boolean> {
+  // Get the last updated cycle from tracker if not provided
+  if (lastStoredReceiptCycle === 0) {
+    const trackedCycle = getLastUpdatedCycle()
+    if (trackedCycle > 0) {
+      Logger.mainLogger.info(`[syncReceiptsByCycle] Using last updated cycle from tracker: ${trackedCycle}`)
+      lastStoredReceiptCycle = Math.max(trackedCycle - config.checkpoint.syncCycleBuffer, 0)
+    }
+  }
+  
   let totalCycles = cycleToSyncTo
   let totalReceipts = 0
   if (cycleToSyncTo === 0) {
@@ -2027,6 +2051,11 @@ export async function syncReceiptsByCycle(lastStoredReceiptCycle = 0, cycleToSyn
       }
       Logger.mainLogger.debug(`Download receipts completed for ${startCycle} - ${endCycle}`)
       // Update checkpoint status for completed cycles
+      
+      // Update the cycle tracker with the latest cycle we've processed
+      updateLastUpdatedCycle(endCycle)
+      Logger.mainLogger.debug(`[syncReceiptsByCycle] Updated cycle tracker to cycle ${endCycle}`)
+      
       startCycle = endCycle + 1
       endCycle += MAX_BETWEEN_CYCLES_PER_REQUEST
       archiverSelector = new ArchiverSelector()
@@ -2274,6 +2303,15 @@ export const syncCyclesAndTxsData = async (
   const MAX_RETRIES = 3
   let retryCount = 0
 
+  // Get the last updated cycle from tracker if not provided
+  if (lastStoredCycleCount === 0) {
+    const trackedCycle = getLastUpdatedCycle()
+    if (trackedCycle > 0) {
+      Logger.mainLogger.info(`[syncCyclesAndTxsData] Using last updated cycle from tracker: ${trackedCycle}`)
+      lastStoredCycleCount = Math.max(trackedCycle - config.checkpoint.syncCycleBuffer, 0)
+    }
+  }
+
   let response: ArchiverTotalDataResponse = await getTotalDataFromArchivers()
   if (!response || response.totalCycles < 0 || response.totalReceipts < 0) {
     return
@@ -2467,6 +2505,13 @@ export const syncCyclesAndTxsData = async (
           }
           success = true
 
+          // Update the cycle tracker with the highest cycle we've processed
+          const highestCycle = cycles.reduce((max, cycle) => Math.max(max, cycle.counter), 0)
+          if (highestCycle > 0) {
+            updateLastUpdatedCycle(highestCycle)
+            Logger.mainLogger.debug(`[syncCyclesAndTxsData] Updated cycle tracker to cycle ${highestCycle}`)
+          }
+          
           if (cycles.length < MAX_CYCLES_PER_REQUEST) {
             startCycle += cycles.length + 1
             endCycle += cycles.length + MAX_CYCLES_PER_REQUEST

--- a/src/State.ts
+++ b/src/State.ts
@@ -14,6 +14,8 @@ import { closeDatabase } from './dbstore'
 import { allowedArchiversManager } from './shardeum/allowedArchiversManager'
 import { customFetch } from './utils/customHttpFunctions'
 import { Utils as StringUtils } from '@shardeum-foundation/lib-types'
+import { updateCycleTrackerOnShutdown } from './utils/cycleTracker'
+
 export interface ArchiverNodeState {
   ip: string
   port: number
@@ -150,7 +152,6 @@ export function addSigListeners(sigint = true, sigterm = true): void {
       Logger.mainLogger.debug('Exiting on SIGINT', process.pid)
       // Update the cycle tracker with the latest unified cycle counter value
       try {
-        const { updateCycleTrackerOnShutdown } = await import('./utils/cycleTracker')
         await updateCycleTrackerOnShutdown()
       } catch (error) {
         Logger.mainLogger.error('Error updating cycle tracker on SIGINT:', error)
@@ -166,7 +167,6 @@ export function addSigListeners(sigint = true, sigterm = true): void {
       Logger.mainLogger.debug('Exiting on SIGTERM', process.pid)
       // Update the cycle tracker with the latest unified cycle counter value
       try {
-        const { updateCycleTrackerOnShutdown } = await import('./utils/cycleTracker')
         await updateCycleTrackerOnShutdown()
       } catch (error) {
         Logger.mainLogger.error('Error updating cycle tracker on SIGTERM:', error)

--- a/src/State.ts
+++ b/src/State.ts
@@ -148,6 +148,13 @@ export function addSigListeners(sigint = true, sigterm = true): void {
   if (sigint) {
     process.on('SIGINT', async () => {
       Logger.mainLogger.debug('Exiting on SIGINT', process.pid)
+      // Update the cycle tracker with the latest unified cycle counter value
+      try {
+        const { updateCycleTrackerOnShutdown } = await import('./utils/cycleTracker')
+        await updateCycleTrackerOnShutdown()
+      } catch (error) {
+        Logger.mainLogger.error('Error updating cycle tracker on SIGINT:', error)
+      }
       await closeDatabase()
       allowedArchiversManager.stopWatching()
       if (isActive) exitArchiver()
@@ -157,6 +164,13 @@ export function addSigListeners(sigint = true, sigterm = true): void {
   if (sigterm) {
     process.on('SIGTERM', async () => {
       Logger.mainLogger.debug('Exiting on SIGTERM', process.pid)
+      // Update the cycle tracker with the latest unified cycle counter value
+      try {
+        const { updateCycleTrackerOnShutdown } = await import('./utils/cycleTracker')
+        await updateCycleTrackerOnShutdown()
+      } catch (error) {
+        Logger.mainLogger.error('Error updating cycle tracker on SIGTERM:', error)
+      }
       await closeDatabase()
       allowedArchiversManager.stopWatching()
       if (isActive) exitArchiver()

--- a/src/checkpoint/CheckpointV2.ts
+++ b/src/checkpoint/CheckpointV2.ts
@@ -4,37 +4,55 @@ import * as Data from '../Data/Data'
 import * as Cycles from '../Data/Cycles'
 import { getCheckpointStatus, getCheckpointSyncRange } from '../dbstore/checkpointStatus'
 
+import { getLastUpdatedCycle, updateLastUpdatedCycle } from '../utils/cycleTracker'
+
 /**
  * Syncs missing or failed checkpoint data
  * @param maxCyclesToSync Maximum number of cycles to sync in one go
  */
 export async function syncMissingCheckpoints(maxCyclesToSync: number = 10): Promise<void> {
   try {
-    // Get the range of cycles that need syncing
-    const syncRange = await getCheckpointSyncRange()
-    if (!syncRange) {
+    // Get all cycles that need syncing (have unified status = false)
+    const cyclesToSync = await getCheckpointSyncRange()
+    if (!cyclesToSync || cyclesToSync.length === 0) {
       Logger.mainLogger.debug('No checkpoints need syncing')
       return
     }
 
-    const { minCycle, maxCycle } = syncRange
     if (config.VERBOSE) {
-      Logger.mainLogger.info(`Syncing checkpoints from cycle ${minCycle} to ${maxCycle}`)
+      Logger.mainLogger.info(`Found ${cyclesToSync.length} cycles that need syncing`)
     }
 
-    // Limit the number of cycles to sync at once
-    const endCycle = Math.min(minCycle + maxCyclesToSync - 1, maxCycle)
-
-    // Process each cycle in the sync range
-    for (let cycle = minCycle; cycle <= endCycle; cycle++) {
-      // Check if we need to sync cycle data
-      const cycleStatus = await getCheckpointStatus(cycle)
-      const needsSync = !cycleStatus || cycleStatus.cycleStatus === false || cycleStatus.unifiedStatus === false
-      if (needsSync) {
-        // Sync cycle data
-        await Data.syncCycleData(cycle)
-        // Sync receipt data
-        await Data.syncReceiptsByCycle(cycle, cycle)
+    // Get the last updated cycle from tracker file
+    const lastUpdatedCycle = getLastUpdatedCycle()
+    Logger.mainLogger.debug(`[syncMissingCheckpoints] Last updated cycle from tracker: ${lastUpdatedCycle}`)
+    
+    // Process all cycles in batches of maxCyclesToSync
+    for (let i = 0; i < cyclesToSync.length; i += maxCyclesToSync) {
+      // Get the next batch of cycles to process
+      const batchCycles = cyclesToSync.slice(i, i + maxCyclesToSync)
+      Logger.mainLogger.debug(`[syncMissingCheckpoints] Processing batch of ${batchCycles.length} cycles (${i+1}-${i+batchCycles.length} of ${cyclesToSync.length})`)
+      
+      // Process each cycle in the current batch
+      for (const cycle of batchCycles) {
+        try {
+          // Check if we need to sync cycle data
+          const cycleStatus = await getCheckpointStatus(cycle)
+          const needsSync = !cycleStatus || cycleStatus.cycleStatus === false || cycleStatus.unifiedStatus === false
+          
+          if (needsSync) {
+            Logger.mainLogger.debug(`[syncMissingCheckpoints] Syncing data for cycle ${cycle}`)
+            // Sync cycle data
+            await Data.syncCycleData(cycle)
+            // Sync receipt data
+            await Data.syncReceiptsByCycle(cycle, cycle)
+            
+            // Update the tracker with the latest cycle we've processed
+            updateLastUpdatedCycle(cycle)
+          }
+        } catch (cycleError) {
+          Logger.mainLogger.error(`[syncMissingCheckpoints] Error syncing cycle ${cycle}:`, cycleError)
+        }
       }
     }
   } catch (error) {

--- a/src/dbstore/checkpointStatus.ts
+++ b/src/dbstore/checkpointStatus.ts
@@ -426,33 +426,26 @@ export async function getOldestPendingOrFailedCheckpointStatus(): Promise<Checkp
 }
 
 /**
- * Gets the range of cycles that need syncing
- * @returns Object with min and max cycle numbers that need syncing
+ * Gets all cycles that need syncing (have unified status = false)
+ * @returns Array of cycle numbers that need syncing
  */
-export async function getCheckpointSyncRange(): Promise<{ minCycle: number; maxCycle: number } | null> {
+export async function getCheckpointSyncRange(): Promise<number[] | null> {
   try {
     const sql = `
-      SELECT MIN(cycle) as minCycle, MAX(cycle) as maxCycle
+      SELECT cycle
       FROM checkpoint_status
       WHERE unifiedStatus = ?
+      ORDER BY cycle ASC
     `
 
-    const result = await db.get(checkpointStatusDatabase, sql, [false])
+    const results = await db.all(checkpointStatusDatabase, sql, [false])
 
-    // Add type assertion to fix TypeScript errors
-    const typedResult = result as {
-      minCycle: number | null
-      maxCycle: number | null
-    }
-
-    if (!typedResult || typedResult.minCycle === null || typedResult.maxCycle === null) {
+    if (!results || results.length === 0) {
       return null
     }
 
-    return {
-      minCycle: typedResult.minCycle,
-      maxCycle: typedResult.maxCycle,
-    }
+    // Extract cycle numbers from results
+    return results.map((row: any) => row.cycle)
   } catch (err) {
     Logger.mainLogger.error('Error getting checkpoint sync range:', err)
     throw err

--- a/src/dbstore/cycles.ts
+++ b/src/dbstore/cycles.ts
@@ -203,3 +203,34 @@ export async function queryCyleCount(): Promise<number> {
   else cycles = 0
   return cycles
 }
+
+/**
+ * Query a cycle by its counter value
+ * @param counter The cycle counter to query
+ * @returns The cycle object or null if not found
+ */
+export async function queryCycleByCounter(counter: number): Promise<Cycle | null> {
+  try {
+    const sql = `SELECT * FROM cycles WHERE counter = ? LIMIT 1`
+    const dbCycle = (await db.get(cycleDatabase, sql, [counter])) as DbCycle
+    
+    if (!dbCycle) {
+      return null
+    }
+    
+    const cycle: Cycle = {
+      counter: dbCycle.counter,
+      cycleRecord: DeSerializeFromJsonString(dbCycle.cycleRecord),
+      cycleMarker: dbCycle.cycleMarker,
+    }
+    
+    if (config.VERBOSE) {
+      Logger.mainLogger.debug('Queried cycle by counter', counter, cycle.cycleMarker)
+    }
+    
+    return cycle
+  } catch (e) {
+    Logger.mainLogger.error(`Error querying cycle by counter ${counter}:`, e)
+    return null
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -494,9 +494,43 @@ async function handleReceiptSyncWithCheckpoints(
   const updatedCycleInfo = (await CycleDB.queryLatestCycleRecords(1))[0]
 
   if (updatedCycleCount - 1 !== updatedCycleInfo.counter) {
-    throw Error(
-      `The archiver has ${updatedCycleCount} cycles but the latest stored cycle is ${updatedCycleInfo.counter}`
+    Logger.mainLogger.error(
+      `Cycle count mismatch: The archiver has ${updatedCycleCount} cycles but the latest stored cycle is ${updatedCycleInfo.counter}`
     )
+    
+    // Import the cycle tracker
+    const { getLastUpdatedCycle } = await import('./utils/cycleTracker')
+    
+    // Get the last updated cycle from tracker file
+    const lastUpdatedCycle = getLastUpdatedCycle()
+    const startCycle = lastUpdatedCycle > 0 ? lastUpdatedCycle - 1 : 0
+    Logger.mainLogger.debug(`[handleReceiptSyncWithCheckpoints] Starting cycle check from last updated cycle: ${startCycle}`)
+    
+    // Find missing cycles and fetch them, starting from the last updated cycle
+    const missingCycles = []
+    for (let i = startCycle; i < updatedCycleCount; i++) {
+      try {
+        const cycleInfo = await CycleDB.queryCycleByCounter(i)
+        if (!cycleInfo) {
+          missingCycles.push(i)
+        }
+      } catch (err) {
+        missingCycles.push(i)
+      }
+    }
+    
+    if (missingCycles.length > 0) {
+      Logger.mainLogger.info(`[handleReceiptSyncWithCheckpoints] Found ${missingCycles.length} missing cycles: ${missingCycles.join(', ')}`)
+      
+      // Fetch missing cycles
+      for (const cycle of missingCycles) {
+        try {
+          await Data.syncCycleData(cycle)
+        } catch (err) {
+          Logger.mainLogger.error(`[handleReceiptSyncWithCheckpoints] Failed to sync missing cycle ${cycle}:`, err)
+        }
+      }
+    }
   }
 
   await Data.syncCyclesAndTxsData(updatedCycleCount, updatedReceiptCount)

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import { RequestDataType } from './API'
 import { getOldestPendingOrFailedCheckpointStatus } from './dbstore/checkpointStatus'
 import { ArchiverLogging } from './profiler/archiverLogging'
 import { logEnvSetup } from './utils/environment'
+import { getLastUpdatedCycle } from './utils/cycleTracker'
 
 const configFile = resolve(__dirname, '../archiver-config.json')
 const allowedArchiversConfigPath = join(__dirname, '../allowed-archivers.json')
@@ -497,15 +498,14 @@ async function handleReceiptSyncWithCheckpoints(
     Logger.mainLogger.error(
       `Cycle count mismatch: The archiver has ${updatedCycleCount} cycles but the latest stored cycle is ${updatedCycleInfo.counter}`
     )
-    
-    // Import the cycle tracker
-    const { getLastUpdatedCycle } = await import('./utils/cycleTracker')
-    
+
     // Get the last updated cycle from tracker file
     const lastUpdatedCycle = getLastUpdatedCycle()
     const startCycle = lastUpdatedCycle > 0 ? lastUpdatedCycle - 1 : 0
-    Logger.mainLogger.debug(`[handleReceiptSyncWithCheckpoints] Starting cycle check from last updated cycle: ${startCycle}`)
-    
+    Logger.mainLogger.debug(
+      `[handleReceiptSyncWithCheckpoints] Starting cycle check from last updated cycle: ${startCycle}`
+    )
+
     // Find missing cycles and fetch them, starting from the last updated cycle
     const missingCycles = []
     for (let i = startCycle; i < updatedCycleCount; i++) {
@@ -518,10 +518,12 @@ async function handleReceiptSyncWithCheckpoints(
         missingCycles.push(i)
       }
     }
-    
+
     if (missingCycles.length > 0) {
-      Logger.mainLogger.info(`[handleReceiptSyncWithCheckpoints] Found ${missingCycles.length} missing cycles: ${missingCycles.join(', ')}`)
-      
+      Logger.mainLogger.info(
+        `[handleReceiptSyncWithCheckpoints] Found ${missingCycles.length} missing cycles: ${missingCycles.join(', ')}`
+      )
+
       // Fetch missing cycles
       for (const cycle of missingCycles) {
         try {

--- a/src/utils/cycleTracker.ts
+++ b/src/utils/cycleTracker.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as Logger from '../Logger'
+import { getCheckpointStatusesByUnifiedStatus } from '../dbstore/checkpointStatus'
+
+interface CycleTrackerData {
+  lastUpdatedCycle: number
+  lastUpdatedTimestamp: number
+}
+
+const CYCLE_TRACKER_FILE = path.join(process.cwd(), 'cycle-tracker.json')
+
+/**
+ * Gets the last updated cycle from the tracker file
+ * @returns The last updated cycle number, or 0 if not found
+ */
+export function getLastUpdatedCycle(): number {
+  try {
+    // If the file does not exist, create it with default values
+    if (!fs.existsSync(CYCLE_TRACKER_FILE)) {
+      const trackerData: CycleTrackerData = {
+        lastUpdatedCycle: 0,
+        lastUpdatedTimestamp: 0
+      }
+
+      fs.writeFileSync(CYCLE_TRACKER_FILE, JSON.stringify(trackerData, null, 2), 'utf8')
+    }
+
+    const data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+    const trackerData: CycleTrackerData = JSON.parse(data)
+    return trackerData.lastUpdatedCycle
+  } catch (error) {
+    Logger.mainLogger.error('Error reading cycle tracker file:', error)
+    return 0
+  }
+}
+
+/**
+ * Updates the last updated cycle in the tracker file
+ * @param cycle The cycle number to update
+ */
+export function updateLastUpdatedCycle(cycle: number): void {
+  const lastUpdatedCycle = getLastUpdatedCycle()
+  if (cycle > lastUpdatedCycle) {
+    try {
+      const trackerData: CycleTrackerData = {
+        lastUpdatedCycle: cycle,
+        lastUpdatedTimestamp: Date.now()
+      }
+
+      fs.writeFileSync(CYCLE_TRACKER_FILE, JSON.stringify(trackerData, null, 2), 'utf8')
+      Logger.mainLogger.debug(`Updated cycle tracker to cycle ${cycle}`)
+    } catch (error) {
+      Logger.mainLogger.error('Error updating cycle tracker file:', error)
+    }
+  }
+}
+
+/**
+ * Gets the latest unified cycle counter value from the checkpoint status database
+ * excluding the latest 21 cycles since the checkpoint system works on those
+ * @returns The latest unified cycle number before the latest 21 cycles, or 0 if not found
+ */
+async function getLatestUnifiedCycle(): Promise<number> {
+  try {
+    // Get all checkpoint statuses with unified status = true
+    const unifiedStatuses = await getCheckpointStatusesByUnifiedStatus(true)
+    
+    if (!unifiedStatuses || unifiedStatuses.length === 0) {
+      Logger.mainLogger.warn('No unified cycle statuses found')
+      return 0
+    }
+    
+    // Sort by cycle in descending order
+    const sortedStatuses = unifiedStatuses.sort((a, b) => b.cycle - a.cycle)
+    
+    // Skip the latest 21 cycles (if available) and get the next unified cycle
+    const LATEST_CYCLES_TO_SKIP = 21
+    
+    if (sortedStatuses.length <= LATEST_CYCLES_TO_SKIP) {
+      // If we have fewer than or equal to 21 unified cycles, we can't get a cycle before the latest 21
+      Logger.mainLogger.warn(`Not enough unified cycles available (${sortedStatuses.length}). Need more than ${LATEST_CYCLES_TO_SKIP} cycles.`)
+      return 0
+    }
+    
+    // Return the cycle number at index 21 (which is the 22nd item, after skipping 21 items)
+    return sortedStatuses[LATEST_CYCLES_TO_SKIP].cycle
+  } catch (error) {
+    Logger.mainLogger.error('Error getting latest unified cycle:', error)
+    return 0
+  }
+}
+
+/**
+ * Updates the cycle tracker with the latest unified cycle counter value
+ * This is called during shutdown to ensure we have the latest cycle information
+ */
+export async function updateCycleTrackerOnShutdown(): Promise<void> {
+  try {
+    // Get the latest unified cycle counter value
+    const latestUnifiedCycle = await getLatestUnifiedCycle()
+    
+    if (latestUnifiedCycle > 0) {
+      Logger.mainLogger.info(`Updating cycle tracker with latest unified cycle: ${latestUnifiedCycle}`)
+      updateLastUpdatedCycle(latestUnifiedCycle)
+    } else {
+      Logger.mainLogger.warn('No valid unified cycle found during shutdown')
+    }
+  } catch (error) {
+    Logger.mainLogger.error('Error updating cycle tracker during shutdown:', error)
+  }
+}

--- a/src/utils/cycleTracker.ts
+++ b/src/utils/cycleTracker.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as Logger from '../Logger'
 import { getCheckpointStatusesByUnifiedStatus } from '../dbstore/checkpointStatus'
+import { config } from '../Config'
 
 interface CycleTrackerData {
   lastUpdatedCycle: number
@@ -20,7 +21,7 @@ export function getLastUpdatedCycle(): number {
     if (!fs.existsSync(CYCLE_TRACKER_FILE)) {
       const trackerData: CycleTrackerData = {
         lastUpdatedCycle: 0,
-        lastUpdatedTimestamp: 0
+        lastUpdatedTimestamp: 0,
       }
 
       fs.writeFileSync(CYCLE_TRACKER_FILE, JSON.stringify(trackerData, null, 2), 'utf8')
@@ -45,7 +46,7 @@ export function updateLastUpdatedCycle(cycle: number): void {
     try {
       const trackerData: CycleTrackerData = {
         lastUpdatedCycle: cycle,
-        lastUpdatedTimestamp: Date.now()
+        lastUpdatedTimestamp: Date.now(),
       }
 
       fs.writeFileSync(CYCLE_TRACKER_FILE, JSON.stringify(trackerData, null, 2), 'utf8')
@@ -65,24 +66,27 @@ async function getLatestUnifiedCycle(): Promise<number> {
   try {
     // Get all checkpoint statuses with unified status = true
     const unifiedStatuses = await getCheckpointStatusesByUnifiedStatus(true)
-    
+
     if (!unifiedStatuses || unifiedStatuses.length === 0) {
       Logger.mainLogger.warn('No unified cycle statuses found')
       return 0
     }
-    
+
     // Sort by cycle in descending order
     const sortedStatuses = unifiedStatuses.sort((a, b) => b.cycle - a.cycle)
-    
+
     // Skip the latest 21 cycles (if available) and get the next unified cycle
-    const LATEST_CYCLES_TO_SKIP = 21
-    
+    const LATEST_CYCLES_TO_SKIP =
+      Math.ceil(config.checkpoint.bucketConfig.GiveUpAge / config.checkpoint.bucketConfig.cycleAge) + 1
+
     if (sortedStatuses.length <= LATEST_CYCLES_TO_SKIP) {
       // If we have fewer than or equal to 21 unified cycles, we can't get a cycle before the latest 21
-      Logger.mainLogger.warn(`Not enough unified cycles available (${sortedStatuses.length}). Need more than ${LATEST_CYCLES_TO_SKIP} cycles.`)
+      Logger.mainLogger.warn(
+        `Not enough unified cycles available (${sortedStatuses.length}). Need more than ${LATEST_CYCLES_TO_SKIP} cycles.`
+      )
       return 0
     }
-    
+
     // Return the cycle number at index 21 (which is the 22nd item, after skipping 21 items)
     return sortedStatuses[LATEST_CYCLES_TO_SKIP].cycle
   } catch (error) {
@@ -99,7 +103,7 @@ export async function updateCycleTrackerOnShutdown(): Promise<void> {
   try {
     // Get the latest unified cycle counter value
     const latestUnifiedCycle = await getLatestUnifiedCycle()
-    
+
     if (latestUnifiedCycle > 0) {
       Logger.mainLogger.info(`Updating cycle tracker with latest unified cycle: ${latestUnifiedCycle}`)
       updateLastUpdatedCycle(latestUnifiedCycle)

--- a/src/utils/cycleTracker.ts
+++ b/src/utils/cycleTracker.ts
@@ -17,17 +17,38 @@ const CYCLE_TRACKER_FILE = path.join(process.cwd(), 'cycle-tracker.json')
  */
 export function getLastUpdatedCycle(): number {
   try {
-    // If the file does not exist, create it with default values
-    if (!fs.existsSync(CYCLE_TRACKER_FILE)) {
-      const trackerData: CycleTrackerData = {
-        lastUpdatedCycle: 0,
-        lastUpdatedTimestamp: 0,
-      }
+    let data: string
 
-      fs.writeFileSync(CYCLE_TRACKER_FILE, JSON.stringify(trackerData, null, 2), 'utf8')
+    try {
+      data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        const trackerData: CycleTrackerData = {
+          lastUpdatedCycle: 0,
+          lastUpdatedTimestamp: 0,
+        }
+
+        try {
+          const fd = fs.openSync(
+            CYCLE_TRACKER_FILE,
+            fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+            0o600
+          )
+          fs.writeFileSync(fd, JSON.stringify(trackerData, null, 2), 'utf8')
+          fs.closeSync(fd)
+          return 0
+        } catch (createError) {
+          if ((createError as NodeJS.ErrnoException).code === 'EEXIST') {
+            data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+          } else {
+            throw createError
+          }
+        }
+      } else {
+        throw error
+      }
     }
 
-    const data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
     const trackerData: CycleTrackerData = JSON.parse(data)
     return trackerData.lastUpdatedCycle
   } catch (error) {

--- a/test/unit/src/Config.test.ts
+++ b/test/unit/src/Config.test.ts
@@ -92,6 +92,7 @@ describe('Config Module', () => {
         maxCyclesToSync: 100,
         syncOnStartup: false,
         statusArraySize: 5000,
+        syncCycleBuffer: 50,
       })
 
       // Data logging

--- a/test/unit/src/dbstore/receipts.test.ts
+++ b/test/unit/src/dbstore/receipts.test.ts
@@ -137,6 +137,7 @@ describe('Receipt Database Operations', () => {
       maxCyclesToSync: 1000,
       syncOnStartup: true,
       statusArraySize: 5000,
+      syncCycleBuffer: 50,
     }
     config.VERBOSE = false
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced persistent cycle tracker for sync progress

- Improved receipt and checkpoint sync to use tracker

- Enhanced shutdown logic to update cycle tracker

- Fixed receipt storage verification for archiver receipts


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>cycleTracker.ts</strong><dd><code>Add persistent cycle tracker utility module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-0fee8682195cf9dad155629694d9118c281bb45cc2ad6d9af5caf5c630eb10e9">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Data.ts</strong><dd><code>Integrate cycle tracker into sync logic and update on progress</code></dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-4966c3a37bd22c2d8ac54814304e5d4160c0cd9e1398b4e1dc7812ed8eba3178">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CheckpointV2.ts</strong><dd><code>Batch checkpoint sync and update tracker per cycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-54d4a00bc3104ecfb86d8ff95d82a010fccdb5a8da68e5969b81c6c7381e6f3a">+36/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>checkpointStatus.ts</strong><dd><code>Refactor sync range to return array of cycles needing sync</code></dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-7b77cdd3f66c966066ab65d0adefbfd371da730c9db7247327706854dff77233">+9/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>State.ts</strong><dd><code>Update cycle tracker on SIGINT/SIGTERM shutdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-23846e7017830c3f2421953a7afd6893754fd0e13830b9242e89b6fc956bde50">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.ts</strong><dd><code>Use cycle tracker to recover and fetch missing cycles</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycles.ts</strong><dd><code>Add queryCycleByCounter for cycle existence checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-f605dae95f495088e2cd11813ebad42469f4b2672babe6004732882770ffa61f">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Config.ts</strong><dd><code>Add syncCycleBuffer config for cycle tracker integration</code>&nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Collector.ts</strong><dd><code>Fix storeReceiptData verification for archiver receipts</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shardeum/archiver/pull/262/files#diff-186c711dbe48d8ffd4c6488e2d29090dae64abd946a5cf185a549af2c556a72e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>