### PR TITLE
Improvements for cycle tracker

### DIFF
--- a/src/Data/Data.ts
+++ b/src/Data/Data.ts
@@ -1827,7 +1827,7 @@ export async function syncReceipts(): Promise<void> {
   let retryCount = 0
 
   // Get the last updated cycle from tracker file
-  const lastUpdatedCycle = getLastUpdatedCycle()
+  const lastUpdatedCycle = await getLastUpdatedCycle()
   Logger.mainLogger.debug(`[syncReceipts] Last updated cycle from tracker: ${lastUpdatedCycle}`)
 
   // If we have a valid last updated cycle, use it as the starting point
@@ -1963,7 +1963,7 @@ class ArchiverSelector {
 export async function syncReceiptsByCycle(lastStoredReceiptCycle = 0, cycleToSyncTo = 0): Promise<boolean> {
   // Get the last updated cycle from tracker if not provided
   if (lastStoredReceiptCycle === 0) {
-    const trackedCycle = getLastUpdatedCycle()
+    const trackedCycle = await getLastUpdatedCycle()
     if (trackedCycle > 0) {
       Logger.mainLogger.info(`[syncReceiptsByCycle] Using last updated cycle from tracker: ${trackedCycle}`)
       lastStoredReceiptCycle = Math.max(trackedCycle - config.checkpoint.syncCycleBuffer, 0)
@@ -2357,7 +2357,7 @@ export const syncCyclesAndTxsData = async (
 
   // Get the last updated cycle from tracker if not provided
   if (lastStoredCycleCount === 0) {
-    const trackedCycle = getLastUpdatedCycle()
+    const trackedCycle = await getLastUpdatedCycle()
     if (trackedCycle > 0) {
       Logger.mainLogger.info(`[syncCyclesAndTxsData] Using last updated cycle from tracker: ${trackedCycle}`)
       lastStoredCycleCount = Math.max(trackedCycle - config.checkpoint.syncCycleBuffer, 0)

--- a/src/checkpoint/CheckpointV2.ts
+++ b/src/checkpoint/CheckpointV2.ts
@@ -12,7 +12,7 @@ import { processCyclesNeedingSync } from '../dbstore/checkpointStatus'
 export async function syncMissingCheckpoints(maxCyclesToSync: number = 100): Promise<void> {
   try {
     // Get the last updated cycle from tracker file
-    const lastUpdatedCycle = getLastUpdatedCycle()
+    const lastUpdatedCycle = await getLastUpdatedCycle()
     Logger.mainLogger.debug(`[syncMissingCheckpoints] Last updated cycle from tracker: ${lastUpdatedCycle}`)
 
     // Get the current network cycle count

--- a/src/dbstore/checkpointStatus.ts
+++ b/src/dbstore/checkpointStatus.ts
@@ -389,6 +389,43 @@ export async function getCheckpointStatusesByUnifiedStatus(unified: boolean, min
 }
 
 /**
+ * Gets a specific unified cycle based on the provided parameters
+ * @param minCycle The minimum cycle to start from
+ * @param skipCount Number of cycles to skip from the top (for skipping recent cycles)
+ * @returns The cycle number or null if not found
+ */
+export async function getSpecificUnifiedCycle(minCycle: number = 0, skipCount: number = 0): Promise<number | null> {
+  try {
+    // Build a query that gets the nth unified cycle in descending order
+    const sql = `
+      SELECT cycle FROM checkpoint_status
+      WHERE unifiedStatus = 1
+      ${minCycle > 0 ? 'AND cycle >= ?' : ''}
+      ORDER BY cycle DESC
+      LIMIT 1 OFFSET ?
+    `
+
+    const params = []
+    if (minCycle > 0) {
+      params.push(minCycle)
+    }
+    params.push(skipCount)
+
+    const row = await db.get(checkpointStatusDatabase, sql, params)
+
+    if (!row) {
+      return null
+    }
+
+    const typedRow = row as { cycle: number }
+    return typedRow.cycle
+  } catch (error) {
+    Logger.mainLogger.error(`Error getting specific unified cycle: ${error}`)
+    throw error
+  }
+}
+
+/**
  * Gets the oldest pending or failed checkpoint status
  * @returns The oldest pending or failed checkpoint status or null if none found
  */
@@ -468,8 +505,13 @@ export async function processCyclesNeedingSync(
       for (let cycle = startCycle; cycle <= endCycle; cycle++) {
         // If no status exists or unified status is false, this cycle needs syncing
         if (!statusMap.has(cycle) || statusMap.get(cycle) === false) {
-          await callback(cycle)
           Logger.mainLogger.debug(`[processCyclesNeedingSync] cycle ${cycle} has unifiedStatus false.. syncing`)
+          await callback(cycle)
+          // Update the checkpoint status to mark it as unified after syncing
+          await updateCheckpointStatusField(cycle, CheckpointStatusType.CYCLE, true)
+          await updateCheckpointStatusField(cycle, CheckpointStatusType.RECEIPT, true)
+          await updateCheckpointStatusField(cycle, CheckpointStatusType.ORIGINAL_TX, true)
+          Logger.mainLogger.debug(`[processCyclesNeedingSync] Updated cycle ${cycle} unifiedStatus to true`)
         }
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -341,7 +341,7 @@ async function syncAndStartServer(): Promise<void> {
     // Get the latest cycle from archivers to know how far we need to sync
     const latestNetworkCycle = await Cycles.getNewestCycleFromArchivers()
     // Get the last updated cycle from tracker file
-    const lastStoredCycle = getLastUpdatedCycle()
+    const lastStoredCycle = await getLastUpdatedCycle()
     State.setLastCycleToSync(lastStoredCycle || latestNetworkCycle?.counter || oldestFailedCheckpointStatus?.cycle || 0)
 
     // Validate and sync cycle data if checkpoint updates are not allowed
@@ -506,7 +506,7 @@ async function handleReceiptSyncWithCheckpoints(
     )
 
     // Get the last updated cycle from tracker file
-    const lastUpdatedCycle = getLastUpdatedCycle()
+    const lastUpdatedCycle = await getLastUpdatedCycle()
     const startCycle = lastUpdatedCycle > 0 ? lastUpdatedCycle - 1 : 0
     Logger.mainLogger.debug(
       `[handleReceiptSyncWithCheckpoints] Starting cycle check from last updated cycle: ${startCycle}`

--- a/src/utils/cycleTracker.ts
+++ b/src/utils/cycleTracker.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as Logger from '../Logger'
-import { getCheckpointStatusesByUnifiedStatus } from '../dbstore/checkpointStatus'
+import { getCheckpointStatusesByUnifiedStatus, getOldestPendingOrFailedCheckpointStatus, getSpecificUnifiedCycle } from '../dbstore/checkpointStatus'
 import { config } from '../Config'
 
 interface CycleTrackerData {
@@ -15,7 +15,7 @@ const CYCLE_TRACKER_FILE = path.join(process.cwd(), 'cycle-tracker.json')
  * Gets the last updated cycle from the tracker file
  * @returns The last updated cycle number, or 0 if not found
  */
-export function getLastUpdatedCycle(): number {
+export async function getLastUpdatedCycle(): Promise<number> {
   try {
     let data: string
 
@@ -23,25 +23,83 @@ export function getLastUpdatedCycle(): number {
       data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        const trackerData: CycleTrackerData = {
-          lastUpdatedCycle: 0,
-          lastUpdatedTimestamp: 0,
-        }
-
+        // If file doesn't exist, try to get the oldest pending or failed checkpoint status
         try {
-          const fd = fs.openSync(
-            CYCLE_TRACKER_FILE,
-            fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
-            0o600
-          )
-          fs.writeFileSync(fd, JSON.stringify(trackerData, null, 2), 'utf8')
-          fs.closeSync(fd)
-          return 0
-        } catch (createError) {
-          if ((createError as NodeJS.ErrnoException).code === 'EEXIST') {
-            data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+          const oldestPendingOrFailedStatus = await getOldestPendingOrFailedCheckpointStatus()
+          if (oldestPendingOrFailedStatus) {
+            Logger.mainLogger.info(`No cycle tracker file found. Using oldest pending/failed checkpoint cycle: ${oldestPendingOrFailedStatus.cycle}`)
+            
+            // Create the tracker file with the oldest pending/failed cycle
+            const trackerData: CycleTrackerData = {
+              lastUpdatedCycle: oldestPendingOrFailedStatus.cycle,
+              lastUpdatedTimestamp: Date.now(),
+            }
+            
+            try {
+              const fd = fs.openSync(
+                CYCLE_TRACKER_FILE,
+                fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+                0o600
+              )
+              fs.writeFileSync(fd, JSON.stringify(trackerData, null, 2), 'utf8')
+              fs.closeSync(fd)
+              return oldestPendingOrFailedStatus.cycle
+            } catch (createError) {
+              if ((createError as NodeJS.ErrnoException).code === 'EEXIST') {
+                data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+              } else {
+                throw createError
+              }
+            }
           } else {
-            throw createError
+            // No pending/failed status found, create file with cycle 0
+            Logger.mainLogger.info('No cycle tracker file and no pending/failed checkpoint statuses found. Starting from cycle 0.')
+            const trackerData: CycleTrackerData = {
+              lastUpdatedCycle: 0,
+              lastUpdatedTimestamp: 0,
+            }
+            
+            try {
+              const fd = fs.openSync(
+                CYCLE_TRACKER_FILE,
+                fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+                0o600
+              )
+              fs.writeFileSync(fd, JSON.stringify(trackerData, null, 2), 'utf8')
+              fs.closeSync(fd)
+              return 0
+            } catch (createError) {
+              if ((createError as NodeJS.ErrnoException).code === 'EEXIST') {
+                data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+              } else {
+                throw createError
+              }
+            }
+          }
+        } catch (statusError) {
+          Logger.mainLogger.error('Error getting oldest pending/failed checkpoint status:', statusError)
+          
+          // Create file with cycle 0 as fallback
+          const trackerData: CycleTrackerData = {
+            lastUpdatedCycle: 0,
+            lastUpdatedTimestamp: 0,
+          }
+          
+          try {
+            const fd = fs.openSync(
+              CYCLE_TRACKER_FILE,
+              fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+              0o600
+            )
+            fs.writeFileSync(fd, JSON.stringify(trackerData, null, 2), 'utf8')
+            fs.closeSync(fd)
+            return 0
+          } catch (createError) {
+            if ((createError as NodeJS.ErrnoException).code === 'EEXIST') {
+              data = fs.readFileSync(CYCLE_TRACKER_FILE, 'utf8')
+            } else {
+              throw createError
+            }
           }
         }
       } else {
@@ -61,8 +119,8 @@ export function getLastUpdatedCycle(): number {
  * Updates the last updated cycle in the tracker file
  * @param cycle The cycle number to update
  */
-export function updateLastUpdatedCycle(cycle: number): void {
-  const lastUpdatedCycle = getLastUpdatedCycle()
+export async function updateLastUpdatedCycle(cycle: number): Promise<void> {
+  const lastUpdatedCycle = await getLastUpdatedCycle()
   if (cycle > lastUpdatedCycle) {
     try {
       const trackerData: CycleTrackerData = {
@@ -86,43 +144,31 @@ export function updateLastUpdatedCycle(cycle: number): void {
 async function getLatestUnifiedCycle(): Promise<number> {
   try {
     // Get the last updated cycle from the tracker file
-    const lastUpdatedCycle = getLastUpdatedCycle()
+    const lastUpdatedCycle = await getLastUpdatedCycle()
     
-    // Get checkpoint statuses with unified status = true and cycle >= lastUpdatedCycle
-    const unifiedStatuses = await getCheckpointStatusesByUnifiedStatus(true, lastUpdatedCycle)
-
-    if (!unifiedStatuses || unifiedStatuses.length === 0) {
-      Logger.mainLogger.warn(`No unified cycle statuses found greater than or equal to cycle ${lastUpdatedCycle}`)
-      
-      // If no cycles found, use max(lastUpdatedCycle - LATEST_CYCLES_TO_SKIP, 0) as fallback
-      if (lastUpdatedCycle > 0) {
-        const LATEST_CYCLES_TO_SKIP =
-          Math.ceil(config.checkpoint.bucketConfig.GiveUpAge / config.checkpoint.bucketConfig.cycleAge) + 1
-        
-        const fallbackCycle = Math.max(lastUpdatedCycle - LATEST_CYCLES_TO_SKIP, 0)
-        Logger.mainLogger.info(`Using fallback cycle: ${fallbackCycle} (lastUpdatedCycle: ${lastUpdatedCycle} - LATEST_CYCLES_TO_SKIP: ${LATEST_CYCLES_TO_SKIP})`)
-        return fallbackCycle
-      }
-      return 0
-    }
-
-    // Sort by cycle in descending order
-    const sortedStatuses = unifiedStatuses.sort((a, b) => b.cycle - a.cycle)
-
-    // Skip the latest 21 cycles (if available) and get the next unified cycle
+    // Calculate how many cycles to skip
     const LATEST_CYCLES_TO_SKIP =
       Math.ceil(config.checkpoint.bucketConfig.GiveUpAge / config.checkpoint.bucketConfig.cycleAge) + 1
-
-    if (sortedStatuses.length <= LATEST_CYCLES_TO_SKIP) {
-      // If we have fewer than or equal to 21 unified cycles, we can't get a cycle before the latest 21
-      Logger.mainLogger.warn(
-        `Not enough unified cycles available (${sortedStatuses.length}). Need more than ${LATEST_CYCLES_TO_SKIP} cycles.`
-      )
-      return 0
+    
+    // Get the specific unified cycle directly from the database
+    // This will get the (LATEST_CYCLES_TO_SKIP)th unified cycle
+    const specificCycle = await getSpecificUnifiedCycle(lastUpdatedCycle, LATEST_CYCLES_TO_SKIP)
+    
+    if (specificCycle !== null) {
+      Logger.mainLogger.debug(`Found unified cycle ${specificCycle} after skipping ${LATEST_CYCLES_TO_SKIP} cycles`)
+      return specificCycle
     }
-
-    // Return the cycle number at index 21 (which is the 22nd item, after skipping 21 items)
-    return sortedStatuses[LATEST_CYCLES_TO_SKIP].cycle
+    
+    Logger.mainLogger.warn(`No unified cycle found after skipping ${LATEST_CYCLES_TO_SKIP} cycles from ${lastUpdatedCycle}`)
+    
+    // If no cycles found, use max(lastUpdatedCycle - LATEST_CYCLES_TO_SKIP, 0) as fallback
+    if (lastUpdatedCycle > 0) {
+      const fallbackCycle = Math.max(lastUpdatedCycle - LATEST_CYCLES_TO_SKIP, 0)
+      Logger.mainLogger.info(`Using fallback cycle: ${fallbackCycle} (lastUpdatedCycle: ${lastUpdatedCycle} - LATEST_CYCLES_TO_SKIP: ${LATEST_CYCLES_TO_SKIP})`)
+      return fallbackCycle
+    }
+    
+    return 0
   } catch (error) {
     Logger.mainLogger.error('Error getting latest unified cycle:', error)
     return 0


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored cycle tracker to use async/await for file and DB operations

- Improved fallback logic for missing cycle tracker file

- Added DB query for specific unified cycle skipping recent cycles

- Updated checkpoint sync logic to mark cycles unified after syncing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cycleTracker.ts</strong><dd><code>Async refactor and fallback improvements for cycle tracker</code></dd></summary>
<hr>

src/utils/cycleTracker.ts

<li>Refactored <code>getLastUpdatedCycle</code> and <code>updateLastUpdatedCycle</code> to <br>async/await<br> <li> Enhanced fallback logic for missing tracker file using DB status<br> <li> Replaced unified cycle query logic with DB-level skip/offset<br> <li> Improved error handling and logging throughout


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/266/files#diff-0fee8682195cf9dad155629694d9118c281bb45cc2ad6d9af5caf5c630eb10e9">+100/-54</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>checkpointStatus.ts</strong><dd><code>Add DB unified cycle query and sync status update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/dbstore/checkpointStatus.ts

<li>Added <code>getSpecificUnifiedCycle</code> for DB-level cycle skipping<br> <li> Updated <code>processCyclesNeedingSync</code> to mark cycles unified after syncing<br> <li> Improved error handling and logging


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/266/files#diff-7b77cdd3f66c966066ab65d0adefbfd371da730c9db7247327706854dff77233">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Data.ts</strong><dd><code>Use async cycle tracker in data sync functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Data/Data.ts

<li>Refactored all usages of <code>getLastUpdatedCycle</code> to async/await<br> <li> Improved cycle determination logic for syncing


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/266/files#diff-4966c3a37bd22c2d8ac54814304e5d4160c0cd9e1398b4e1dc7812ed8eba3178">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CheckpointV2.ts</strong><dd><code>Use async cycle tracker in checkpoint sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/checkpoint/CheckpointV2.ts

<li>Refactored to use async <code>getLastUpdatedCycle</code><br> <li> Improved logging for checkpoint sync


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/266/files#diff-54d4a00bc3104ecfb86d8ff95d82a010fccdb5a8da68e5969b81c6c7381e6f3a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.ts</strong><dd><code>Use async cycle tracker in server startup and sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.ts

<li>Refactored to use async <code>getLastUpdatedCycle</code> in server startup and sync<br> <li> Improved state initialization logic


</details>


  </td>
  <td><a href="https://github.com/shardeum/archiver/pull/266/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>